### PR TITLE
Add camp schedule meta and bind camp-times on variations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@
 This plugin enhances the WooCommerce booking system for InterSoccer Switzerland by managing complex product variations, dynamic pricing calculations, and sophisticated sibling discount systems. It supports three main product types: Camps (full-week and single-day), Courses (seasonal with prorated pricing), and Birthdays, with comprehensive admin interfaces and multilingual support.
 
 ## Version
-- **Version: 2.7.17**
-- Release Date: July 17, 2026
+- **Version: 2.7.18**
+- Release Date: July 19, 2026
+
+## Camp schedule meta (2.7.18)
+
+Camp variations store `_camp_start_date`, `_camp_end_date`, and `_camp_week_index`. Program Manager can edit/pre-fill these and seed them from camp-terms via `wp intersoccer migrate-camp-dates`. Parsing dates from `pa_camp-terms` remains a **deprecated fallback** during migration — see `scratch/BACKLOG-remove-camp-terms-date-parse.md` and `.cursor/rules/camp-date-meta.mdc`.
 
 ## Features
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -136,3 +136,88 @@ function intersoccer_late_pickup_admin_fields_submitted($variation_id, $loop) {
 
     return false;
 }
+
+/**
+ * Canonical full-day camp time slug (10:00–17:00) used by the live catalogue.
+ */
+if (!defined('INTERSOCCER_CAMP_TIME_FULL_DAY')) {
+    define('INTERSOCCER_CAMP_TIME_FULL_DAY', '1000-1700');
+}
+
+/**
+ * Canonical half-day / Mini camp time slug (10:00–12:30) used by the live catalogue.
+ */
+if (!defined('INTERSOCCER_CAMP_TIME_HALF_DAY')) {
+    define('INTERSOCCER_CAMP_TIME_HALF_DAY', '1000-1230');
+}
+
+/**
+ * Preferred camp-time slug for an age-group slug (Full Day vs Half Day).
+ *
+ * Prefers matches from $allowed_time_slugs when provided; otherwise falls back to
+ * catalogue defaults. Returns empty string when no safe match exists in a non-empty pool.
+ *
+ * @param string   $age_slug            pa_age-group term slug.
+ * @param string[] $allowed_time_slugs  Optional pool (parent product times).
+ * @return string
+ */
+function intersoccer_pm_default_camp_time_slug_for_age($age_slug, $allowed_time_slugs = []) {
+    $age_slug = is_string($age_slug) ? strtolower(trim($age_slug)) : '';
+    if (function_exists('sanitize_title')) {
+        $age_slug = sanitize_title((string) $age_slug);
+    }
+    $allowed = array_values(array_filter(array_map('strval', (array) $allowed_time_slugs)));
+
+    $is_half = function_exists('intersoccer_is_half_day_age_group')
+        ? intersoccer_is_half_day_age_group('', $age_slug)
+        : (strpos($age_slug, 'half-day') !== false || strpos($age_slug, 'half_day') !== false);
+
+    $preferred = $is_half
+        ? [
+            INTERSOCCER_CAMP_TIME_HALF_DAY,
+            '1000-1200',
+            '0900-1200',
+            '1000-1230',
+        ]
+        : [
+            INTERSOCCER_CAMP_TIME_FULL_DAY,
+            '1000-1700',
+            '1000-1500',
+            '0900-1700',
+        ];
+
+    /**
+     * Filter preferred camp-time slug candidates for an age group.
+     *
+     * @param string[] $preferred Preferred slugs (first match wins).
+     * @param string   $age_slug
+     * @param bool     $is_half
+     * @param string[] $allowed
+     */
+    if (function_exists('apply_filters')) {
+        $preferred = apply_filters('intersoccer_pm_camp_time_slug_candidates', $preferred, $age_slug, $is_half, $allowed);
+    }
+
+    $pool = !empty($allowed) ? $allowed : $preferred;
+
+    foreach ($preferred as $candidate) {
+        if (in_array($candidate, $pool, true)) {
+            return $candidate;
+        }
+    }
+
+    if (!empty($allowed)) {
+        foreach ($allowed as $slug) {
+            $s = strtolower((string) $slug);
+            if ($is_half && (preg_match('/12[0-3]0$/', $s) || strpos($s, '1200') !== false || strpos($s, '1230') !== false)) {
+                return $slug;
+            }
+            if (!$is_half && (preg_match('/17[0-3]0$/', $s) || strpos($s, '1700') !== false || strpos($s, '1500') !== false)) {
+                return $slug;
+            }
+        }
+        return '';
+    }
+
+    return $is_half ? INTERSOCCER_CAMP_TIME_HALF_DAY : INTERSOCCER_CAMP_TIME_FULL_DAY;
+}

--- a/includes/woocommerce/age-group-verification.php
+++ b/includes/woocommerce/age-group-verification.php
@@ -278,6 +278,8 @@ function intersoccer_get_variation_program_season_string($product_id, $variation
 /**
  * Parse camp start date (Y-m-d) from pa_camp-terms slug and season (ported from roster logic).
  *
+ * @deprecated since 2.7.18 Remove in 2.9.0 or next major — prefer `_camp_start_date` variation meta via intersoccer_get_camp_schedule().
+ *
  * @param string $camp_terms_slug Camp terms slug.
  * @param string $season          Season string for year extraction.
  * @return string|null
@@ -418,6 +420,7 @@ function intersoccer_program_reference_date_from_discovery_inputs($course_start_
     if ($course_start_ymd !== '' && preg_match('/^\d{4}-\d{2}-\d{2}$/', $course_start_ymd)) {
         return $course_start_ymd;
     }
+    // Optional 5th arg used by callers that already know variation id — keep signature stable.
     $from_camp = intersoccer_parse_camp_start_date_from_terms((string) $camp_terms_slug, (string) $season_str);
     if ($from_camp) {
         return $from_camp;
@@ -483,6 +486,13 @@ function intersoccer_get_program_reference_date($product_id, $variation_id, $pro
                 break;
 
             case 'camp':
+                if ($variation_id && function_exists('intersoccer_get_camp_schedule')) {
+                    $schedule = intersoccer_get_camp_schedule((int) $variation_id, true);
+                    if (!empty($schedule['start'])) {
+                        $computed = $schedule['start'];
+                        break;
+                    }
+                }
                 $camp_terms = intersoccer_get_camp_terms_slug($product_id, $variation_id);
                 $season = intersoccer_get_variation_program_season_string($product_id, $variation_id);
                 $computed = intersoccer_parse_camp_start_date_from_terms($camp_terms, $season);
@@ -503,10 +513,18 @@ function intersoccer_get_program_reference_date($product_id, $variation_id, $pro
         if ($variation_id && function_exists('intersoccer_get_course_meta')) {
             $course_start = (string) intersoccer_get_course_meta((int) $variation_id, '_course_start_date', '');
         }
-        $camp_terms = intersoccer_get_camp_terms_slug($product_id, $variation_id);
-        $season = intersoccer_get_variation_program_season_string($product_id, $variation_id);
-        $event_raw = intersoccer_get_first_raw_event_date_attribute($product_id, $variation_id);
-        $computed = intersoccer_program_reference_date_from_discovery_inputs($course_start, $camp_terms, $season, $event_raw);
+        if ($variation_id && function_exists('intersoccer_get_camp_schedule')) {
+            $sched = intersoccer_get_camp_schedule((int) $variation_id, true);
+            if (!empty($sched['start'])) {
+                $computed = $sched['start'];
+            }
+        }
+        if ($computed === null) {
+            $camp_terms = intersoccer_get_camp_terms_slug($product_id, $variation_id);
+            $season = intersoccer_get_variation_program_season_string($product_id, $variation_id);
+            $event_raw = intersoccer_get_first_raw_event_date_attribute($product_id, $variation_id);
+            $computed = intersoccer_program_reference_date_from_discovery_inputs($course_start, $camp_terms, $season, $event_raw);
+        }
     }
 
     /**

--- a/includes/woocommerce/attribute-registry.php
+++ b/includes/woocommerce/attribute-registry.php
@@ -216,7 +216,11 @@ function intersoccer_attr_registry() {
             ],
             'legacy_taxonomy_aliases' => ['pa_camp_times'],
             'legacy_meta_keys' => ['attribute_pa_camp_times'],
-            'default_terms' => [],
+            // Catalogue defaults: Full Day 10:00–17:00, Half Day Mini 10:00–12:30.
+            'default_terms' => [
+                ['name' => '1000-1700', 'slug' => '1000-1700'],
+                ['name' => '1000-1230', 'slug' => '1000-1230'],
+            ],
             'day_attribute' => false,
         ],
         'girls-only' => [
@@ -305,8 +309,8 @@ function intersoccer_attr_product_type_templates() {
     $templates = [
         'camp' => [
             'parent' => array_merge($core_parent, ['girls-only', 'days-of-week', 'camp-terms', 'camp-times']),
-            'variation' => ['booking-type', 'age-group'],
-            'meta' => [],
+            'variation' => ['booking-type', 'age-group', 'camp-times'],
+            'meta' => ['_camp_start_date', '_camp_end_date', '_camp_week_index'],
         ],
         'course' => [
             'parent' => array_merge($core_parent, ['girls-only']),
@@ -458,7 +462,7 @@ function intersoccer_attr_health_required_keys($product_type) {
     $type = strtolower((string) $product_type);
     $keys = intersoccer_attr_required($type, 'variation');
 
-    if ($type === 'course') {
+    if ($type === 'course' || $type === 'camp') {
         $keys = array_merge($keys, intersoccer_attr_required($type, 'meta'));
     }
 
@@ -477,6 +481,7 @@ function intersoccer_attr_refresh_defaults($product_type) {
         'camp' => [
             'pa_booking-type' => 'full-week',
             'pa_age-group' => '5-13y-full-day',
+            'pa_camp-times' => '1000-1700',
         ],
         'course' => [
             'pa_course-day' => 'monday',

--- a/includes/woocommerce/camp-schedule-migrate.php
+++ b/includes/woocommerce/camp-schedule-migrate.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Migrate camp schedule meta from deprecated camp-terms string parsing.
+ *
+ * @package InterSoccer_Product_Variations
+ * @since 2.7.18
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Migrate camp dates for one variable product.
+ *
+ * @param int   $product_id Product ID.
+ * @param array $args {
+ *     @type bool $force   Overwrite existing start dates.
+ *     @type bool $dry_run Do not write.
+ * }
+ * @return array|WP_Error
+ */
+function intersoccer_migrate_camp_dates_for_product($product_id, $args = []) {
+	$args = array_merge([
+		'force'   => false,
+		'dry_run' => false,
+	], is_array($args) ? $args : []);
+
+	$product_id = (int) $product_id;
+	if ($product_id <= 0) {
+		return new WP_Error('invalid_product', __('Invalid or non-variable product.', 'intersoccer-product-variations'));
+	}
+	$product = function_exists('wc_get_product') ? wc_get_product($product_id) : null;
+	if (!$product || !is_object($product) || !method_exists($product, 'is_type') || !$product->is_type('variable')) {
+		return new WP_Error('invalid_product', __('Invalid or non-variable product.', 'intersoccer-product-variations'));
+	}
+
+	$type = class_exists('InterSoccer_Product_Types')
+		? InterSoccer_Product_Types::get_product_type($product_id)
+		: '';
+
+	if ($type !== 'camp') {
+		return new WP_Error('not_camp', __('Product is not a camp.', 'intersoccer-product-variations'));
+	}
+
+	$result = [
+		'product_id' => $product_id,
+		'updated'    => 0,
+		'skipped'    => 0,
+		'failed'     => 0,
+		'rows'       => [],
+	];
+
+	foreach ($product->get_children() as $var_id) {
+		$meta = function_exists('intersoccer_get_camp_schedule_meta')
+			? intersoccer_get_camp_schedule_meta($var_id)
+			: ['start' => '', 'end' => '', 'week' => null];
+
+		if ($meta['start'] !== '' && !$args['force']) {
+			$result['skipped']++;
+			$result['rows'][] = [
+				'variation_id' => $var_id,
+				'status'       => 'skipped',
+				'reason'       => 'already_has_start',
+			];
+			continue;
+		}
+
+		$terms = '';
+		if (function_exists('intersoccer_get_camp_terms_slug')) {
+			$terms = intersoccer_get_camp_terms_slug($product_id, $var_id);
+		}
+		$variation = wc_get_product($var_id);
+		if ($terms === '' && $variation) {
+			$terms = (string) $variation->get_attribute('pa_camp-terms');
+		}
+
+		$season = '';
+		if (function_exists('intersoccer_get_variation_program_season_string')) {
+			$season = intersoccer_get_variation_program_season_string($product_id, $var_id);
+		}
+
+		$parsed = function_exists('intersoccer_camp_schedule_from_terms_deprecated')
+			? intersoccer_camp_schedule_from_terms_deprecated($terms, $season)
+			: ['start' => '', 'end' => '', 'week' => null];
+
+		if ($parsed['start'] === '') {
+			$result['failed']++;
+			$result['rows'][] = [
+				'variation_id' => $var_id,
+				'status'       => 'failed',
+				'reason'       => 'unparseable',
+				'camp_terms'   => $terms,
+			];
+			continue;
+		}
+
+		if (!$args['dry_run'] && function_exists('intersoccer_update_camp_schedule')) {
+			intersoccer_update_camp_schedule(
+				$var_id,
+				$parsed['start'],
+				$parsed['end'],
+				$parsed['week'],
+				true
+			);
+		}
+
+		$result['updated']++;
+		$result['rows'][] = [
+			'variation_id' => $var_id,
+			'status'       => $args['dry_run'] ? 'would_update' : 'updated',
+			'schedule'     => [
+				'start' => $parsed['start'],
+				'end'   => $parsed['end'],
+				'week'  => $parsed['week'],
+			],
+		];
+	}
+
+	if (!$args['dry_run']) {
+		wc_delete_product_transients($product_id);
+	}
+
+	return $result;
+}
+
+/**
+ * Migrate all camp products.
+ *
+ * @param array $args force, dry_run.
+ * @return array
+ */
+function intersoccer_migrate_camp_dates_all($args = []) {
+	$args = array_merge([
+		'force'   => false,
+		'dry_run' => false,
+	], is_array($args) ? $args : []);
+
+	$summary = [
+		'products' => 0,
+		'updated'  => 0,
+		'skipped'  => 0,
+		'failed'   => 0,
+		'details'  => [],
+	];
+
+	$query = new WP_Query([
+		'post_type'      => 'product',
+		'post_status'    => ['publish', 'draft', 'private'],
+		'posts_per_page' => -1,
+		'fields'         => 'ids',
+		'tax_query'      => [
+			[
+				'taxonomy' => 'product_type',
+				'field'    => 'slug',
+				'terms'    => 'variable',
+			],
+		],
+	]);
+
+	foreach ($query->posts as $product_id) {
+		$type = class_exists('InterSoccer_Product_Types')
+			? InterSoccer_Product_Types::get_product_type((int) $product_id)
+			: '';
+		if ($type !== 'camp') {
+			continue;
+		}
+		$summary['products']++;
+		$one = intersoccer_migrate_camp_dates_for_product((int) $product_id, $args);
+		if (is_wp_error($one)) {
+			$summary['failed']++;
+			$summary['details'][] = ['product_id' => (int) $product_id, 'error' => $one->get_error_message()];
+			continue;
+		}
+		$summary['updated'] += (int) $one['updated'];
+		$summary['skipped'] += (int) $one['skipped'];
+		$summary['failed']  += (int) $one['failed'];
+		$summary['details'][] = $one;
+	}
+
+	return $summary;
+}
+
+if (defined('WP_CLI') && WP_CLI) {
+	/**
+	 * Migrate camp start/end/week meta from camp-terms parsing.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--product=<id>]
+	 * : Limit to one product ID.
+	 *
+	 * [--force]
+	 * : Overwrite existing `_camp_start_date` values.
+	 *
+	 * [--dry-run]
+	 * : Report only; do not write meta.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp intersoccer migrate-camp-dates --dry-run
+	 *     wp intersoccer migrate-camp-dates --product=39700
+	 */
+	WP_CLI::add_command('intersoccer migrate-camp-dates', function ($args, $assoc_args) {
+		$opts = [
+			'force'   => isset($assoc_args['force']),
+			'dry_run' => isset($assoc_args['dry-run']),
+		];
+
+		if (!empty($assoc_args['product'])) {
+			$result = intersoccer_migrate_camp_dates_for_product((int) $assoc_args['product'], $opts);
+			if (is_wp_error($result)) {
+				WP_CLI::error($result->get_error_message());
+			}
+			WP_CLI::success(sprintf(
+				'Product %d: updated=%d skipped=%d failed=%d%s',
+				$result['product_id'],
+				$result['updated'],
+				$result['skipped'],
+				$result['failed'],
+				$opts['dry_run'] ? ' (dry-run)' : ''
+			));
+			return;
+		}
+
+		$summary = intersoccer_migrate_camp_dates_all($opts);
+		WP_CLI::success(sprintf(
+			'Camps=%d updated=%d skipped=%d failed=%d%s',
+			$summary['products'],
+			$summary['updated'],
+			$summary['skipped'],
+			$summary['failed'],
+			$opts['dry_run'] ? ' (dry-run)' : ''
+		));
+	});
+}

--- a/includes/woocommerce/camp-schedule.php
+++ b/includes/woocommerce/camp-schedule.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * Camp schedule meta: first-class start/end/week on variations.
+ *
+ * Source of truth: `_camp_start_date`, `_camp_end_date`, `_camp_week_index`.
+ * String parsing of pa_camp-terms is deprecated transitional fallback.
+ *
+ * @package InterSoccer_Product_Variations
+ * @since 2.7.18
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/** @var bool Flag for removal tracking — set false only after parse helpers are deleted. */
+if (!defined('INTERSOCCER_CAMP_TERMS_DATE_PARSE_DEPRECATED')) {
+	define('INTERSOCCER_CAMP_TERMS_DATE_PARSE_DEPRECATED', true);
+}
+
+/**
+ * Camp schedule meta keys stored on variations.
+ *
+ * @return array{start:string,end:string,week:string}
+ */
+function intersoccer_camp_schedule_meta_keys() {
+	return [
+		'start' => '_camp_start_date',
+		'end'   => '_camp_end_date',
+		'week'  => '_camp_week_index',
+	];
+}
+
+/**
+ * Normalize a Y-m-d date string or return empty.
+ *
+ * @param mixed $value Raw value.
+ * @return string
+ */
+function intersoccer_camp_schedule_normalize_ymd($value) {
+	$value = is_string($value) ? trim($value) : '';
+	if ($value === '' || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+		return '';
+	}
+	$ts = strtotime($value . ' 00:00:00');
+	return $ts ? date('Y-m-d', $ts) : '';
+}
+
+/**
+ * Read raw schedule meta from a variation (no fallback).
+ *
+ * @param int $variation_id Variation ID.
+ * @return array{start:string,end:string,week:int|null}
+ */
+function intersoccer_get_camp_schedule_meta($variation_id) {
+	$variation_id = (int) $variation_id;
+	$keys         = intersoccer_camp_schedule_meta_keys();
+	$start        = $variation_id ? intersoccer_camp_schedule_normalize_ymd(get_post_meta($variation_id, $keys['start'], true)) : '';
+	$end          = $variation_id ? intersoccer_camp_schedule_normalize_ymd(get_post_meta($variation_id, $keys['end'], true)) : '';
+	$week_raw     = $variation_id ? get_post_meta($variation_id, $keys['week'], true) : '';
+	$week         = ($week_raw !== '' && $week_raw !== null && is_numeric($week_raw)) ? (int) $week_raw : null;
+
+	return [
+		'start' => $start,
+		'end'   => $end,
+		'week'  => $week,
+	];
+}
+
+/**
+ * Persist camp schedule meta on a variation.
+ *
+ * @param int         $variation_id Variation ID.
+ * @param string|null $start        Y-m-d or empty to clear.
+ * @param string|null $end          Y-m-d or empty to clear.
+ * @param int|null    $week         Week index or null to leave unchanged when $week_set false.
+ * @param bool        $week_set     Whether to write week (including clearing with null/0).
+ * @return bool
+ */
+function intersoccer_update_camp_schedule($variation_id, $start = null, $end = null, $week = null, $week_set = true) {
+	$variation_id = (int) $variation_id;
+	if ($variation_id <= 0) {
+		return false;
+	}
+
+	$keys = intersoccer_camp_schedule_meta_keys();
+
+	if ($start !== null) {
+		$norm = intersoccer_camp_schedule_normalize_ymd((string) $start);
+		if ($norm === '') {
+			delete_post_meta($variation_id, $keys['start']);
+		} else {
+			update_post_meta($variation_id, $keys['start'], $norm);
+		}
+	}
+
+	if ($end !== null) {
+		$norm = intersoccer_camp_schedule_normalize_ymd((string) $end);
+		if ($norm === '') {
+			delete_post_meta($variation_id, $keys['end']);
+		} else {
+			update_post_meta($variation_id, $keys['end'], $norm);
+		}
+	}
+
+	if ($week_set) {
+		if ($week === null || (int) $week <= 0) {
+			delete_post_meta($variation_id, $keys['week']);
+		} else {
+			update_post_meta($variation_id, $keys['week'], (int) $week);
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Deprecated: derive schedule from camp-terms label/slug + season.
+ *
+ * @deprecated since 2.7.18 Remove in 2.9.0 or next major — camp dates must live in variation meta.
+ *
+ * @param string $camp_terms Camp terms slug or display label.
+ * @param string $season     Season string (for year).
+ * @return array{start:string,end:string,week:int|null,source:string}
+ */
+function intersoccer_camp_schedule_from_terms_deprecated($camp_terms, $season = '') {
+	$camp_terms = trim((string) $camp_terms);
+	$season     = (string) $season;
+	$result     = [
+		'start'  => '',
+		'end'    => '',
+		'week'   => null,
+		'source' => 'terms_parse',
+	];
+
+	if ($camp_terms === '' || $camp_terms === 'N/A') {
+		return $result;
+	}
+
+	if (function_exists('intersoccer_parse_camp_dates_fixed')) {
+		list($start, $end) = intersoccer_parse_camp_dates_fixed($camp_terms, $season);
+		$result['start'] = intersoccer_camp_schedule_normalize_ymd((string) $start);
+		$result['end']   = intersoccer_camp_schedule_normalize_ymd((string) $end);
+	} elseif (function_exists('intersoccer_parse_camp_start_date_from_terms')) {
+		$start = intersoccer_parse_camp_start_date_from_terms($camp_terms, $season);
+		$result['start'] = intersoccer_camp_schedule_normalize_ymd((string) $start);
+		// Best-effort end from same-month / cross-month slug patterns when RR helper absent.
+		if ($result['start'] !== '' && preg_match('/(\w+)[\s\-]+(\d{1,2})[\s\-]+(?:(\w+)[\s\-]+)?(\d{1,2})/i', $camp_terms, $m)) {
+			// Prefer dedicated PV end parse via start+duration from "(N days)" when present.
+			if (preg_match('/\((\d+)\s*days?\)/i', $camp_terms, $dm)) {
+				$days = max(1, (int) $dm[1]);
+				$ts   = strtotime($result['start'] . ' 00:00:00');
+				if ($ts) {
+					$result['end'] = date('Y-m-d', strtotime('+' . ($days - 1) . ' days', $ts));
+				}
+			}
+		}
+	}
+
+	if (function_exists('intersoccer_parse_camp_week_from_terms')) {
+		$week = intersoccer_parse_camp_week_from_terms($camp_terms);
+		$result['week'] = $week !== null ? (int) $week : null;
+	} elseif (preg_match('/week[\s\-]+(\d+)/i', $camp_terms, $wm)) {
+		$result['week'] = (int) $wm[1];
+	}
+
+	return $result;
+}
+
+/**
+ * Rate-limited debug when deprecated camp-terms parse is used.
+ *
+ * @param int    $variation_id Variation ID.
+ * @param string $context      Caller context.
+ */
+function intersoccer_camp_schedule_log_deprecated_parse($variation_id, $context = '') {
+	if (!INTERSOCCER_CAMP_TERMS_DATE_PARSE_DEPRECATED) {
+		return;
+	}
+	if (!defined('WP_DEBUG') || !WP_DEBUG) {
+		return;
+	}
+	$bucket = 'intersoccer_camp_terms_parse_' . gmdate('YmdH');
+	$count  = (int) get_transient($bucket);
+	if ($count >= 20) {
+		return;
+	}
+	set_transient($bucket, $count + 1, HOUR_IN_SECONDS);
+	if (function_exists('intersoccer_debug')) {
+		intersoccer_debug(sprintf(
+			'InterSoccer: DEPRECATED camp-terms date parse used (variation=%d context=%s). Prefer _camp_start_date/_camp_end_date.',
+			(int) $variation_id,
+			$context
+		));
+	}
+}
+
+/**
+ * Resolve camp schedule for a variation: meta first, then deprecated terms parse.
+ *
+ * @param int  $variation_id Variation ID.
+ * @param bool $allow_fallback Whether to parse camp-terms when meta incomplete.
+ * @return array{start:string,end:string,week:int|null,source:string}
+ */
+function intersoccer_get_camp_schedule($variation_id, $allow_fallback = true) {
+	$variation_id = (int) $variation_id;
+	$meta         = intersoccer_get_camp_schedule_meta($variation_id);
+	$out          = [
+		'start'  => $meta['start'],
+		'end'    => $meta['end'],
+		'week'   => $meta['week'],
+		'source' => 'meta',
+	];
+
+	$needs_dates = ($out['start'] === '' || $out['end'] === '');
+	$needs_week  = ($out['week'] === null);
+
+	if (!$allow_fallback || (!$needs_dates && !$needs_week)) {
+		return $out;
+	}
+
+	$product = wc_get_product($variation_id);
+	if (!$product) {
+		return $out;
+	}
+
+	$parent_id = $product->get_parent_id() ?: $variation_id;
+	$terms     = '';
+	if (function_exists('intersoccer_get_camp_terms_slug')) {
+		$terms = intersoccer_get_camp_terms_slug($parent_id, $variation_id);
+	}
+	if ($terms === '') {
+		$terms = (string) $product->get_attribute('pa_camp-terms');
+	}
+
+	$season = '';
+	if (function_exists('intersoccer_get_variation_program_season_string')) {
+		$season = intersoccer_get_variation_program_season_string($parent_id, $variation_id);
+	}
+
+	$parsed = intersoccer_camp_schedule_from_terms_deprecated($terms, $season);
+	intersoccer_camp_schedule_log_deprecated_parse($variation_id, 'intersoccer_get_camp_schedule');
+
+	if ($out['start'] === '' && $parsed['start'] !== '') {
+		$out['start']  = $parsed['start'];
+		$out['source'] = 'terms_parse';
+	}
+	if ($out['end'] === '' && $parsed['end'] !== '') {
+		$out['end']    = $parsed['end'];
+		$out['source'] = 'terms_parse';
+	}
+	if ($out['week'] === null && $parsed['week'] !== null) {
+		$out['week']   = $parsed['week'];
+		$out['source'] = ($out['source'] === 'meta' && $out['start'] !== '' && $meta['start'] !== '') ? 'meta' : 'terms_parse';
+	}
+
+	return $out;
+}
+
+/**
+ * Propose start/end for week N from a week-1 anchor.
+ *
+ * @param string $week1_start Y-m-d.
+ * @param int    $week_index  1-based week index.
+ * @param int    $duration_days Inclusive day count (default 5).
+ * @return array{start:string,end:string}
+ */
+function intersoccer_camp_schedule_propose_from_week1($week1_start, $week_index, $duration_days = 5) {
+	$week1_start   = intersoccer_camp_schedule_normalize_ymd($week1_start);
+	$week_index    = max(1, (int) $week_index);
+	$duration_days = max(1, (int) $duration_days);
+
+	if ($week1_start === '') {
+		return ['start' => '', 'end' => ''];
+	}
+
+	$ts = strtotime($week1_start . ' 00:00:00');
+	if (!$ts) {
+		return ['start' => '', 'end' => ''];
+	}
+
+	$offset = ($week_index - 1) * 7;
+	$start  = date('Y-m-d', strtotime('+' . $offset . ' days', $ts));
+	$end    = date('Y-m-d', strtotime('+' . ($duration_days - 1) . ' days', strtotime($start . ' 00:00:00')));
+
+	return ['start' => $start, 'end' => $end];
+}

--- a/includes/woocommerce/discounts.php
+++ b/includes/woocommerce/discounts.php
@@ -485,8 +485,15 @@ function intersoccer_extract_camp_items_from_order($order) {
             }
         }
         
-        // Parse week number from camp-terms
-        $week_number = intersoccer_parse_camp_week_from_terms($camp_terms);
+        // Week index: prefer variation meta, fall back to deprecated camp-terms parse.
+        $week_number = null;
+        if ($variation_id && function_exists('intersoccer_get_camp_schedule')) {
+            $schedule = intersoccer_get_camp_schedule((int) $variation_id, true);
+            $week_number = $schedule['week'];
+        }
+        if ($week_number === null) {
+            $week_number = intersoccer_parse_camp_week_from_terms($camp_terms);
+        }
         
         $camp_items[] = [
             'order_id' => $order->get_id(),
@@ -510,7 +517,9 @@ function intersoccer_extract_camp_items_from_order($order) {
 
 /**
  * Parse week number from camp-terms attribute
- * 
+ *
+ * @deprecated since 2.7.18 Remove in 2.9.0 or next major — prefer `_camp_week_index` variation meta.
+ *
  * @param string $camp_terms Camp terms string (e.g., "summer-week-2-june-24-june-28-5-days")
  * @return int|null Week number or null if not found
  */
@@ -1402,7 +1411,14 @@ function intersoccer_apply_combo_discounts_to_items($cart) {
                         }
                     }
                     
-                    $current_week = intersoccer_parse_camp_week_from_terms($camp_terms);
+                    $current_week = null;
+                    if ($variation_id && function_exists('intersoccer_get_camp_schedule')) {
+                        $schedule = intersoccer_get_camp_schedule((int) $variation_id, true);
+                        $current_week = $schedule['week'];
+                    }
+                    if ($current_week === null) {
+                        $current_week = intersoccer_parse_camp_week_from_terms($camp_terms);
+                    }
                     if (!$current_week) {
                         continue; // Skip if we can't determine week number
                     }

--- a/includes/woocommerce/order-meta-contract.php
+++ b/includes/woocommerce/order-meta-contract.php
@@ -439,6 +439,23 @@ function intersoccer_build_order_line_meta($args) {
                 $updates['Late Pickup Cost'] = wc_price($cart_values['late_pickup_cost']);
             }
         }
+        // Stamp structured camp schedule onto the order item when variation meta exists.
+        $vid = $variation_id ?: $product_id;
+        if (function_exists('intersoccer_get_camp_schedule_meta')) {
+            $schedule = intersoccer_get_camp_schedule_meta($vid);
+            if ($schedule['start'] !== '') {
+                $updates['Camp Start Date'] = $schedule['start'];
+                $updates['_camp_start_date'] = $schedule['start'];
+            }
+            if ($schedule['end'] !== '') {
+                $updates['Camp End Date'] = $schedule['end'];
+                $updates['_camp_end_date'] = $schedule['end'];
+            }
+            if ($schedule['week'] !== null) {
+                $updates['Camp Week Index'] = (string) $schedule['week'];
+                $updates['_camp_week_index'] = (string) $schedule['week'];
+            }
+        }
     } elseif ($product_type === 'course') {
         $vid = $variation_id ?: $product_id;
         if (function_exists('intersoccer_get_course_meta')) {

--- a/includes/woocommerce/program-manager.php
+++ b/includes/woocommerce/program-manager.php
@@ -34,6 +34,11 @@ class InterSoccer_Program_Manager {
 		add_action('wp_ajax_intersoccer_pm_scaffold_variations', [__CLASS__, 'ajax_scaffold_variations']);
 		add_action('wp_ajax_intersoccer_pm_check_completeness', [__CLASS__, 'ajax_check_completeness']);
 		add_action('wp_ajax_intersoccer_pm_save_variation_price', [__CLASS__, 'ajax_save_variation_price']);
+		add_action('wp_ajax_intersoccer_pm_save_camp_schedule', [__CLASS__, 'ajax_save_camp_schedule']);
+		add_action('wp_ajax_intersoccer_pm_prefill_camp_schedules', [__CLASS__, 'ajax_prefill_camp_schedules']);
+		add_action('wp_ajax_intersoccer_pm_apply_parsed_camp_dates', [__CLASS__, 'ajax_apply_parsed_camp_dates']);
+		add_action('wp_ajax_intersoccer_pm_propose_camp_times', [__CLASS__, 'ajax_propose_camp_times']);
+		add_action('wp_ajax_intersoccer_pm_quick_edit', [__CLASS__, 'ajax_quick_edit']);
 		add_action('wp_ajax_intersoccer_pm_duplicate_program', [__CLASS__, 'ajax_duplicate_program']);
 		add_action('wp_ajax_intersoccer_pm_save_parent_attrs', [__CLASS__, 'ajax_save_parent_attrs']);
 		add_action('wp_ajax_intersoccer_pm_create_term', [__CLASS__, 'ajax_create_term']);
@@ -62,7 +67,7 @@ class InterSoccer_Program_Manager {
 			'intersoccer-program-manager',
 			INTERSOCCER_PRODUCT_VARIATIONS_PLUGIN_URL . 'js/program-manager.js',
 			['jquery'],
-			'1.0.0',
+			'1.2.0',
 			true
 		);
 
@@ -209,7 +214,15 @@ class InterSoccer_Program_Manager {
 		$attributes = $variation->get_attributes();
 
 		foreach ($required as $key) {
-			if (strpos($key, '_course_') === 0 || strpos($key, '_') === 0) {
+			if (strpos($key, '_course_') === 0 || strpos($key, '_camp_') === 0 || strpos($key, '_') === 0) {
+				// Camp week index only required when the variation has camp-terms.
+				if ($key === '_camp_week_index' && $product_type === 'camp') {
+					$terms = get_post_meta($variation_id, 'attribute_pa_camp-terms', true);
+					if (($terms === '' || $terms === null || $terms === false)
+						&& empty($variation->get_attribute('pa_camp-terms'))) {
+						continue;
+					}
+				}
 				$value = get_post_meta($variation_id, $key, true);
 				if ($value === '' || $value === null || $value === false) {
 					$missing[] = $key;
@@ -305,9 +318,9 @@ class InterSoccer_Program_Manager {
 							continue;
 						}
 						$type   = InterSoccer_Product_Types::get_product_type($pid);
-						$matrix = self::get_default_matrix($type);
+						$matrix = self::get_default_matrix($type, $pid);
 						foreach ($matrix as $row) {
-							self::create_single_variation($pid, $row, $type);
+							self::create_single_variation($pid, $type, $row);
 						}
 						$processed++;
 					}
@@ -406,7 +419,7 @@ class InterSoccer_Program_Manager {
 
 			<h2><?php esc_html_e('Parent Attributes', 'intersoccer-product-variations'); ?></h2>
 			<?php
-			$multi_select_slugs = ['days-of-week', 'camp-terms', 'camp-times', 'course-times', 'intersoccer-venues'];
+			$multi_select_slugs = ['days-of-week', 'camp-terms', 'camp-times', 'course-times', 'intersoccer-venues', 'age-group'];
 			$required_parent = intersoccer_attr_required($type, 'parent');
 			?>
 			<table class="widefat striped" style="max-width: 700px;">
@@ -474,12 +487,47 @@ class InterSoccer_Program_Manager {
 				</p>
 			<?php endif; ?>
 
+			<?php if ($type === 'camp') : ?>
+			<div class="intersoccer-pm-camp-schedule-tools" style="margin: 12px 0; padding: 12px; background: #f6f7f7; border: 1px solid #ddd; border-radius: 4px; max-width: 900px;">
+				<h3 style="margin-top:0;"><?php esc_html_e('Camp Schedule', 'intersoccer-product-variations'); ?></h3>
+				<p class="description"><?php esc_html_e('Store start/end dates and week index on each variation. Labels in Camp Terms stay for storefront display.', 'intersoccer-product-variations'); ?></p>
+				<p>
+					<label>
+						<?php esc_html_e('Week 1 start', 'intersoccer-product-variations'); ?>
+						<input type="date" id="intersoccer-pm-week1-start" />
+					</label>
+					&nbsp;
+					<label>
+						<?php esc_html_e('Duration (days)', 'intersoccer-product-variations'); ?>
+						<input type="number" id="intersoccer-pm-week-duration" min="1" max="7" value="5" style="width:60px;" />
+					</label>
+					&nbsp;
+					<button type="button" class="button" id="intersoccer-pm-propose-weeks-btn" data-product-id="<?php echo esc_attr($product_id); ?>">
+						<?php esc_html_e('Propose remaining weeks', 'intersoccer-product-variations'); ?>
+					</button>
+					<button type="button" class="button" id="intersoccer-pm-apply-parsed-dates-btn" data-product-id="<?php echo esc_attr($product_id); ?>">
+						<?php esc_html_e('Apply parsed dates from camp-terms', 'intersoccer-product-variations'); ?>
+					</button>
+					<button type="button" class="button" id="intersoccer-pm-propose-times-btn" data-product-id="<?php echo esc_attr($product_id); ?>">
+						<?php esc_html_e('Propose times from age', 'intersoccer-product-variations'); ?>
+					</button>
+				</p>
+				<p class="description"><?php esc_html_e('Propose fills empty rows only (+7 days per week index). Apply parsed uses the deprecated camp-terms parser once to seed meta. Propose times fills empty pa_camp-times from age (Half Day → 1000-1230, Full Day → 1000-1700).', 'intersoccer-product-variations'); ?></p>
+				<span id="intersoccer-pm-schedule-tools-status"></span>
+			</div>
+			<?php endif; ?>
+
 			<table class="widefat striped intersoccer-pm-variations-table">
 				<thead>
 					<tr>
 						<th><?php esc_html_e('ID', 'intersoccer-product-variations'); ?></th>
 						<th><?php esc_html_e('Attributes', 'intersoccer-product-variations'); ?></th>
 						<th><?php esc_html_e('Price (CHF)', 'intersoccer-product-variations'); ?></th>
+						<?php if ($type === 'camp') : ?>
+							<th><?php esc_html_e('Week', 'intersoccer-product-variations'); ?></th>
+							<th><?php esc_html_e('Start', 'intersoccer-product-variations'); ?></th>
+							<th><?php esc_html_e('End', 'intersoccer-product-variations'); ?></th>
+						<?php endif; ?>
 						<th><?php esc_html_e('Status', 'intersoccer-product-variations'); ?></th>
 						<th><?php esc_html_e('Issues', 'intersoccer-product-variations'); ?></th>
 					</tr>
@@ -502,14 +550,29 @@ class InterSoccer_Program_Manager {
 							}
 						}
 						$price = $variation->get_regular_price();
+						$sched = ($type === 'camp' && function_exists('intersoccer_get_camp_schedule_meta'))
+							? intersoccer_get_camp_schedule_meta($var_id)
+							: ['start' => '', 'end' => '', 'week' => null];
 					?>
-					<tr>
+					<tr data-variation-id="<?php echo esc_attr($var_id); ?>">
 						<td><?php echo esc_html($var_id); ?></td>
 						<td><?php echo esc_html(implode(' | ', $attr_display) ?: '—'); ?></td>
 						<td>
 							<input type="number" step="0.01" min="0" class="intersoccer-pm-price-input" data-variation-id="<?php echo esc_attr($var_id); ?>" value="<?php echo esc_attr($price); ?>" style="width: 100px;" />
 							<span class="intersoccer-pm-price-status"></span>
 						</td>
+						<?php if ($type === 'camp') : ?>
+							<td>
+								<input type="number" min="1" max="52" class="intersoccer-pm-camp-week" data-variation-id="<?php echo esc_attr($var_id); ?>" value="<?php echo esc_attr($sched['week'] !== null ? $sched['week'] : ''); ?>" style="width: 60px;" />
+							</td>
+							<td>
+								<input type="date" class="intersoccer-pm-camp-start" data-variation-id="<?php echo esc_attr($var_id); ?>" value="<?php echo esc_attr($sched['start']); ?>" />
+							</td>
+							<td>
+								<input type="date" class="intersoccer-pm-camp-end" data-variation-id="<?php echo esc_attr($var_id); ?>" value="<?php echo esc_attr($sched['end']); ?>" />
+								<span class="intersoccer-pm-schedule-status"></span>
+							</td>
+						<?php endif; ?>
 						<td>
 							<?php if ($var_result['is_healthy']) : ?>
 								<span style="color:green;">&#10003; <?php esc_html_e('Healthy', 'intersoccer-product-variations'); ?></span>
@@ -647,7 +710,7 @@ class InterSoccer_Program_Manager {
 								$taxonomy = intersoccer_attr_taxonomy($slug);
 								$label    = intersoccer_attr_wc_label($slug) ?: $slug;
 								$terms    = $term_options[$taxonomy] ?? [];
-								$is_multi = in_array($slug, ['days-of-week', 'camp-terms', 'camp-times', 'course-times', 'intersoccer-venues'], true);
+								$is_multi = in_array($slug, ['days-of-week', 'camp-terms', 'camp-times', 'course-times', 'intersoccer-venues', 'age-group'], true);
 						?>
 						<tr class="intersoccer-pm-attr-row" data-types="<?php echo esc_attr($t); ?>" style="display:none;">
 							<th><label><?php echo esc_html($label); ?> *</label></th>
@@ -699,15 +762,15 @@ class InterSoccer_Program_Manager {
 		<!-- Pass variation matrix data to JS -->
 		<script type="text/javascript">
 			var intersoccerPMMatrix = {
-				camp: [
-					{ 'pa_booking-type': 'full-week', 'pa_age-group': '5-13y-full-day', label: '<?php echo esc_js(__('Full Week / Full Day (5-13y)', 'intersoccer-product-variations')); ?>' },
-					{ 'pa_booking-type': 'full-week', 'pa_age-group': '3-5y-half-day', label: '<?php echo esc_js(__('Full Week / Half Day (3-5y)', 'intersoccer-product-variations')); ?>' },
-					{ 'pa_booking-type': 'single-days', 'pa_age-group': '5-13y-full-day', label: '<?php echo esc_js(__('Single Day(s) / Full Day (5-13y)', 'intersoccer-product-variations')); ?>' },
-					{ 'pa_booking-type': 'single-days', 'pa_age-group': '3-5y-half-day', label: '<?php echo esc_js(__('Single Day(s) / Half Day (3-5y)', 'intersoccer-product-variations')); ?>' }
-				],
+				camp: <?php echo wp_json_encode(self::build_camp_matrix_rows()); ?>,
 				course: <?php echo wp_json_encode(self::get_course_matrix_options($term_options)); ?>,
 				birthday: <?php echo wp_json_encode(self::get_birthday_matrix_options($term_options)); ?>,
 				tournament: <?php echo wp_json_encode(self::get_tournament_matrix_options($term_options)); ?>
+			};
+			var intersoccerPMCampDefaults = {
+				ages: ['5-13y-full-day', '3-5y-half-day'],
+				bookings: ['full-week', 'single-days'],
+				times: ['1000-1700', '1000-1230']
 			};
 		</script>
 
@@ -963,14 +1026,22 @@ class InterSoccer_Program_Manager {
 
 		$variations_created = 0;
 		$matrix = isset($_POST['matrix']) && is_array($_POST['matrix']) ? $_POST['matrix'] : [];
+		$times_from_matrix = [];
 		foreach ($matrix as $row) {
 			if (!is_array($row)) {
 				continue;
+			}
+			if (!empty($row['pa_camp-times'])) {
+				$times_from_matrix[] = sanitize_text_field((string) $row['pa_camp-times']);
 			}
 			$var_id = self::create_single_variation($product_id, $type, $row);
 			if ($var_id) {
 				$variations_created++;
 			}
+		}
+
+		if ($type === 'camp' && !empty($times_from_matrix)) {
+			self::ensure_parent_camp_times_variation_attribute($product_id, $times_from_matrix);
 		}
 
 		wc_delete_product_transients($product_id);
@@ -1007,21 +1078,51 @@ class InterSoccer_Program_Manager {
 			wp_send_json_error(['message' => __('Invalid variable product.', 'intersoccer-product-variations')]);
 		}
 
-		$matrix = self::get_default_matrix($type);
+		$matrix = self::get_default_matrix($type, $product_id);
 		$created = 0;
+		$skipped = 0;
+		$times_from_matrix = [];
+
+		$existing_keys = [];
+		foreach ($product->get_children() as $child_id) {
+			$child = wc_get_product($child_id);
+			if (!$child) {
+				continue;
+			}
+			$existing_keys[self::variation_attr_signature($child->get_attributes())] = true;
+		}
 
 		foreach ($matrix as $row) {
+			$sig = self::variation_attr_signature($row);
+			if (isset($existing_keys[$sig])) {
+				$skipped++;
+				continue;
+			}
 			$var_id = self::create_single_variation($product_id, $type, $row);
 			if ($var_id) {
 				$created++;
+				$existing_keys[$sig] = true;
+				if (!empty($row['pa_camp-times'])) {
+					$times_from_matrix[] = (string) $row['pa_camp-times'];
+				}
 			}
+		}
+
+		if ($type === 'camp') {
+			self::ensure_parent_camp_times_variation_attribute($product_id, $times_from_matrix);
 		}
 
 		wc_delete_product_transients($product_id);
 
 		wp_send_json_success([
 			'created' => $created,
-			'message' => sprintf(__('%d variations created.', 'intersoccer-product-variations'), $created),
+			'skipped' => $skipped,
+			'message' => sprintf(
+				/* translators: 1: created count, 2: skipped count */
+				__('%1$d variations created, %2$d already present.', 'intersoccer-product-variations'),
+				$created,
+				$skipped
+			),
 		]);
 	}
 
@@ -1066,6 +1167,265 @@ class InterSoccer_Program_Manager {
 		wc_delete_product_transients($variation->get_parent_id());
 
 		wp_send_json_success(['variation_id' => $variation_id, 'price' => $price]);
+	}
+
+	public static function ajax_save_camp_schedule() {
+		check_ajax_referer(self::NONCE_ACTION, 'nonce');
+
+		if (!current_user_can(self::CAPABILITY)) {
+			wp_send_json_error(['message' => __('Permission denied.', 'intersoccer-product-variations')]);
+		}
+
+		$variation_id = isset($_POST['variation_id']) ? absint($_POST['variation_id']) : 0;
+		$start        = isset($_POST['start']) ? sanitize_text_field(wp_unslash($_POST['start'])) : '';
+		$end          = isset($_POST['end']) ? sanitize_text_field(wp_unslash($_POST['end'])) : '';
+		$week         = isset($_POST['week']) ? absint($_POST['week']) : 0;
+
+		if (!$variation_id || !function_exists('intersoccer_update_camp_schedule')) {
+			wp_send_json_error(['message' => __('Invalid request.', 'intersoccer-product-variations')]);
+		}
+
+		$variation = wc_get_product($variation_id);
+		if (!$variation || !($variation instanceof WC_Product_Variation)) {
+			wp_send_json_error(['message' => __('Invalid variation.', 'intersoccer-product-variations')]);
+		}
+
+		intersoccer_update_camp_schedule($variation_id, $start, $end, $week > 0 ? $week : null, true);
+		wc_delete_product_transients($variation->get_parent_id());
+
+		wp_send_json_success([
+			'variation_id' => $variation_id,
+			'schedule'     => intersoccer_get_camp_schedule_meta($variation_id),
+		]);
+	}
+
+	public static function ajax_prefill_camp_schedules() {
+		check_ajax_referer(self::NONCE_ACTION, 'nonce');
+
+		if (!current_user_can(self::CAPABILITY)) {
+			wp_send_json_error(['message' => __('Permission denied.', 'intersoccer-product-variations')]);
+		}
+
+		$product_id     = isset($_POST['product_id']) ? absint($_POST['product_id']) : 0;
+		$week1_start    = isset($_POST['week1_start']) ? sanitize_text_field(wp_unslash($_POST['week1_start'])) : '';
+		$duration_days  = isset($_POST['duration_days']) ? absint($_POST['duration_days']) : 5;
+		$overwrite      = !empty($_POST['overwrite']);
+
+		$product = wc_get_product($product_id);
+		if (!$product || !$product->is_type('variable') || !function_exists('intersoccer_camp_schedule_propose_from_week1')) {
+			wp_send_json_error(['message' => __('Invalid product.', 'intersoccer-product-variations')]);
+		}
+
+		$updated = 0;
+		$rows    = [];
+		foreach ($product->get_children() as $var_id) {
+			$meta = intersoccer_get_camp_schedule_meta($var_id);
+			$week = $meta['week'];
+			if ($week === null && function_exists('intersoccer_get_camp_schedule')) {
+				$resolved = intersoccer_get_camp_schedule($var_id, true);
+				$week     = $resolved['week'];
+			}
+			if ($week === null || $week < 1) {
+				continue;
+			}
+
+			$has_dates = ($meta['start'] !== '' || $meta['end'] !== '');
+			if ($has_dates && !$overwrite) {
+				continue;
+			}
+
+			$proposed = intersoccer_camp_schedule_propose_from_week1($week1_start, (int) $week, $duration_days);
+			if ($proposed['start'] === '') {
+				continue;
+			}
+
+			intersoccer_update_camp_schedule($var_id, $proposed['start'], $proposed['end'], (int) $week, true);
+			$updated++;
+			$rows[] = [
+				'variation_id' => $var_id,
+				'schedule'     => intersoccer_get_camp_schedule_meta($var_id),
+			];
+		}
+
+		wc_delete_product_transients($product_id);
+		wp_send_json_success(['updated' => $updated, 'rows' => $rows]);
+	}
+
+	public static function ajax_apply_parsed_camp_dates() {
+		check_ajax_referer(self::NONCE_ACTION, 'nonce');
+
+		if (!current_user_can(self::CAPABILITY)) {
+			wp_send_json_error(['message' => __('Permission denied.', 'intersoccer-product-variations')]);
+		}
+
+		$product_id = isset($_POST['product_id']) ? absint($_POST['product_id']) : 0;
+		$force      = !empty($_POST['force']);
+
+		if (!function_exists('intersoccer_migrate_camp_dates_for_product')) {
+			require_once INTERSOCCER_PRODUCT_VARIATIONS_PLUGIN_DIR . 'includes/woocommerce/camp-schedule-migrate.php';
+		}
+
+		$result = intersoccer_migrate_camp_dates_for_product($product_id, [
+			'force'   => $force,
+			'dry_run' => false,
+		]);
+
+		if (is_wp_error($result)) {
+			wp_send_json_error(['message' => $result->get_error_message()]);
+		}
+
+		wp_send_json_success($result);
+	}
+
+	/**
+	 * Fill empty variation pa_camp-times from age slug (non-destructive by default).
+	 */
+	public static function ajax_propose_camp_times() {
+		check_ajax_referer(self::NONCE_ACTION, 'nonce');
+
+		if (!current_user_can(self::CAPABILITY)) {
+			wp_send_json_error(['message' => __('Permission denied.', 'intersoccer-product-variations')]);
+		}
+
+		$product_id = isset($_POST['product_id']) ? absint($_POST['product_id']) : 0;
+		$overwrite  = !empty($_POST['overwrite']);
+
+		$product = wc_get_product($product_id);
+		if (!$product || !$product->is_type('variable')) {
+			wp_send_json_error(['message' => __('Invalid product.', 'intersoccer-product-variations')]);
+		}
+
+		if (!function_exists('intersoccer_pm_default_camp_time_slug_for_age')) {
+			require_once INTERSOCCER_PRODUCT_VARIATIONS_PLUGIN_DIR . 'includes/helpers.php';
+		}
+
+		$allowed_times = wc_get_product_terms($product_id, 'pa_camp-times', ['fields' => 'slugs']);
+		if (is_wp_error($allowed_times)) {
+			$allowed_times = [];
+		}
+
+		$updated = 0;
+		$skipped = 0;
+		$rows    = [];
+
+		foreach ($product->get_children() as $var_id) {
+			$variation = wc_get_product($var_id);
+			if (!$variation || !($variation instanceof WC_Product_Variation)) {
+				continue;
+			}
+
+			$attrs = $variation->get_attributes();
+			$age   = isset($attrs['pa_age-group']) ? (string) $attrs['pa_age-group'] : '';
+			$time  = isset($attrs['pa_camp-times']) ? (string) $attrs['pa_camp-times'] : '';
+
+			if ($time !== '' && !$overwrite) {
+				$skipped++;
+				continue;
+			}
+
+			$proposed = intersoccer_pm_default_camp_time_slug_for_age($age, $allowed_times);
+			if ($proposed === '') {
+				$skipped++;
+				continue;
+			}
+
+			if ($time === $proposed) {
+				$skipped++;
+				continue;
+			}
+
+			$attrs['pa_camp-times'] = $proposed;
+			$variation->set_attributes($attrs);
+			$variation->save();
+			$updated++;
+			$rows[] = [
+				'variation_id' => $var_id,
+				'pa_camp-times' => $proposed,
+				'pa_age-group'  => $age,
+			];
+		}
+
+		// Ensure parent attribute includes proposed times and is used for variations.
+		self::ensure_parent_camp_times_variation_attribute($product_id, array_column($rows, 'pa_camp-times'));
+
+		wc_delete_product_transients($product_id);
+		wp_send_json_success([
+			'updated' => $updated,
+			'skipped' => $skipped,
+			'rows'    => $rows,
+			'message' => sprintf(
+				/* translators: 1: updated count, 2: skipped count */
+				__('Updated %1$d, skipped %2$d.', 'intersoccer-product-variations'),
+				$updated,
+				$skipped
+			),
+		]);
+	}
+
+	public static function ajax_quick_edit() {
+		check_ajax_referer(self::NONCE_ACTION, 'nonce');
+
+		if (!current_user_can(self::CAPABILITY)) {
+			wp_send_json_error(['message' => __('Permission denied.', 'intersoccer-product-variations')]);
+		}
+
+		$product_id = isset($_POST['product_id']) ? absint($_POST['product_id']) : 0;
+		$name       = isset($_POST['name']) ? sanitize_text_field(wp_unslash($_POST['name'])) : '';
+		$status     = isset($_POST['status']) ? sanitize_key(wp_unslash($_POST['status'])) : '';
+		$attrs_raw  = isset($_POST['attrs']) && is_array($_POST['attrs']) ? $_POST['attrs'] : [];
+
+		$product = wc_get_product($product_id);
+		if (!$product || !$product->is_type('variable')) {
+			wp_send_json_error(['message' => __('Invalid product.', 'intersoccer-product-variations')]);
+		}
+
+		if ($name !== '') {
+			$product->set_name($name);
+		}
+		if (in_array($status, ['draft', 'publish', 'private'], true)) {
+			$product->set_status($status);
+		}
+
+		$existing_attributes = $product->get_attributes();
+		foreach ($attrs_raw as $taxonomy => $slugs) {
+			$taxonomy = sanitize_text_field($taxonomy);
+			if (strpos($taxonomy, 'pa_') !== 0) {
+				continue;
+			}
+			if (!is_array($slugs)) {
+				$slugs = [$slugs];
+			}
+			$slugs = array_values(array_filter(array_map('sanitize_text_field', $slugs)));
+			$term_ids = [];
+			foreach ($slugs as $slug) {
+				$term = get_term_by('slug', $slug, $taxonomy);
+				if ($term && !is_wp_error($term)) {
+					$term_ids[] = (int) $term->term_id;
+				}
+			}
+
+			if (isset($existing_attributes[$taxonomy]) && $existing_attributes[$taxonomy] instanceof WC_Product_Attribute) {
+				$attr = clone $existing_attributes[$taxonomy];
+			} else {
+				$attr = new WC_Product_Attribute();
+				$attr->set_id(wc_attribute_taxonomy_id_by_name($taxonomy));
+				$attr->set_name($taxonomy);
+				$attr->set_visible(true);
+				$attr->set_variation(false);
+			}
+			$attr->set_options($term_ids);
+			$existing_attributes[$taxonomy] = $attr;
+		}
+
+		$product->set_attributes($existing_attributes);
+		$product->save();
+		wc_delete_product_transients($product_id);
+
+		wp_send_json_success([
+			'product_id' => $product_id,
+			'name'       => $product->get_name(),
+			'status'     => $product->get_status(),
+		]);
 	}
 
 	public static function ajax_duplicate_program() {
@@ -1280,15 +1640,22 @@ class InterSoccer_Program_Manager {
 		return in_array($taxonomy, $variation_taxonomies, true);
 	}
 
-	private static function get_default_matrix($type) {
+	private static function get_default_matrix($type, $product_id = 0) {
 		switch ($type) {
 			case 'camp':
-				return [
-					['pa_booking-type' => 'full-week', 'pa_age-group' => '5-13y-full-day'],
-					['pa_booking-type' => 'full-week', 'pa_age-group' => '3-5y-half-day'],
-					['pa_booking-type' => 'single-days', 'pa_age-group' => '5-13y-full-day'],
-					['pa_booking-type' => 'single-days', 'pa_age-group' => '3-5y-half-day'],
-				];
+				$ages  = [];
+				$times = [];
+				if ($product_id) {
+					$ages = wc_get_product_terms($product_id, 'pa_age-group', ['fields' => 'slugs']);
+					$times = wc_get_product_terms($product_id, 'pa_camp-times', ['fields' => 'slugs']);
+					if (is_wp_error($ages)) {
+						$ages = [];
+					}
+					if (is_wp_error($times)) {
+						$times = [];
+					}
+				}
+				return self::build_camp_matrix_rows($ages, $times);
 			case 'course':
 				$days = get_terms(['taxonomy' => 'pa_course-day', 'hide_empty' => false]);
 				$ages = get_terms(['taxonomy' => 'pa_age-group', 'hide_empty' => false]);
@@ -1325,6 +1692,129 @@ class InterSoccer_Program_Manager {
 			default:
 				return [];
 		}
+	}
+
+	/**
+	 * Build camp variation matrix: booking-type × age-group × paired camp-times.
+	 *
+	 * @param string[] $age_slugs
+	 * @param string[] $time_slugs Allowed parent times (optional).
+	 * @param string[] $booking_slugs
+	 * @return array<int,array<string,string>>
+	 */
+	public static function build_camp_matrix_rows($age_slugs = [], $time_slugs = [], $booking_slugs = []) {
+		if (!function_exists('intersoccer_pm_default_camp_time_slug_for_age')) {
+			$helpers = INTERSOCCER_PRODUCT_VARIATIONS_PLUGIN_DIR . 'includes/helpers.php';
+			if (is_readable($helpers)) {
+				require_once $helpers;
+			}
+		}
+
+		$ages = array_values(array_filter(array_map('strval', (array) $age_slugs)));
+		if (empty($ages)) {
+			$ages = ['5-13y-full-day', '3-5y-half-day'];
+		}
+
+		$bookings = array_values(array_filter(array_map('strval', (array) $booking_slugs)));
+		if (empty($bookings)) {
+			$bookings = ['full-week', 'single-days'];
+		}
+
+		$times = array_values(array_filter(array_map('strval', (array) $time_slugs)));
+
+		$booking_labels = [
+			'full-week'   => __('Full Week', 'intersoccer-product-variations'),
+			'single-days' => __('Single Day(s)', 'intersoccer-product-variations'),
+		];
+
+		$matrix = [];
+		foreach ($ages as $age) {
+			$time = function_exists('intersoccer_pm_default_camp_time_slug_for_age')
+				? intersoccer_pm_default_camp_time_slug_for_age($age, $times)
+				: '';
+			foreach ($bookings as $booking) {
+				$row = [
+					'pa_booking-type' => $booking,
+					'pa_age-group'    => $age,
+				];
+				if ($time !== '') {
+					$row['pa_camp-times'] = $time;
+				}
+				$parts = [
+					$booking_labels[$booking] ?? $booking,
+					$age,
+				];
+				if ($time !== '') {
+					$parts[] = $time;
+				}
+				$row['label'] = implode(' / ', $parts);
+				$matrix[] = $row;
+			}
+		}
+
+		return $matrix;
+	}
+
+	/**
+	 * Stable signature for variation attribute uniqueness checks.
+	 *
+	 * @param array<string,mixed> $attributes
+	 * @return string
+	 */
+	private static function variation_attr_signature($attributes) {
+		$attrs = [];
+		foreach ((array) $attributes as $key => $value) {
+			if ($key === 'label' || $value === '' || $value === null) {
+				continue;
+			}
+			$tax = (strpos((string) $key, 'pa_') === 0) ? (string) $key : 'pa_' . ltrim((string) $key, '_');
+			$attrs[$tax] = is_array($value) ? implode(',', $value) : (string) $value;
+		}
+		ksort($attrs);
+		return wp_json_encode($attrs);
+	}
+
+	/**
+	 * Ensure pa_camp-times exists on the parent and is used for variations.
+	 *
+	 * @param int      $product_id
+	 * @param string[] $extra_slugs
+	 */
+	private static function ensure_parent_camp_times_variation_attribute($product_id, $extra_slugs = []) {
+		$product = wc_get_product($product_id);
+		if (!$product) {
+			return;
+		}
+
+		$extra_slugs = array_values(array_unique(array_filter(array_map('strval', (array) $extra_slugs))));
+		$current     = wc_get_product_terms($product_id, 'pa_camp-times', ['fields' => 'slugs']);
+		if (is_wp_error($current)) {
+			$current = [];
+		}
+		$merged = array_values(array_unique(array_merge($current, $extra_slugs)));
+		if (empty($merged)) {
+			return;
+		}
+
+		wp_set_object_terms($product_id, $merged, 'pa_camp-times');
+
+		$attributes = $product->get_attributes();
+		$taxonomy   = 'pa_camp-times';
+		if (isset($attributes[$taxonomy]) && is_object($attributes[$taxonomy])) {
+			$attributes[$taxonomy]->set_variation(true);
+			$attributes[$taxonomy]->set_visible(true);
+			$attributes[$taxonomy]->set_options($merged);
+		} else {
+			$attribute = new WC_Product_Attribute();
+			$attribute->set_id(wc_attribute_taxonomy_id_by_name($taxonomy));
+			$attribute->set_name($taxonomy);
+			$attribute->set_options($merged);
+			$attribute->set_visible(true);
+			$attribute->set_variation(true);
+			$attributes[$taxonomy] = $attribute;
+		}
+		$product->set_attributes($attributes);
+		$product->save();
 	}
 
 	/**
@@ -1517,9 +2007,49 @@ class InterSoccer_Program_List_Table extends WP_List_Table {
 				], admin_url('edit.php'));
 				$edit_url = get_edit_post_link($item['product_id'], 'raw');
 
-				return '<a href="' . esc_url($detail_url) . '" class="button button-small">' . esc_html__('Manage', 'intersoccer-product-variations') . '</a> '
+				$render_multi = static function ($taxonomy, $class, $label) use ($item) {
+					$current = wc_get_product_terms($item['product_id'], $taxonomy, ['fields' => 'slugs']);
+					if (!is_array($current)) {
+						$current = [];
+					}
+					$all = get_terms(['taxonomy' => $taxonomy, 'hide_empty' => false]);
+					$html = '<p><label>' . esc_html($label) . '<br /><select class="' . esc_attr($class) . '" multiple size="4" style="width:100%;min-width:220px;">';
+					if (!is_wp_error($all)) {
+						foreach ($all as $term) {
+							$html .= '<option value="' . esc_attr($term->slug) . '"' . selected(in_array($term->slug, $current, true), true, false) . '>'
+								. esc_html($term->name) . '</option>';
+						}
+					}
+					$html .= '</select></label></p>';
+					return $html;
+				};
+
+				$qe = '<button type="button" class="button button-small intersoccer-pm-quick-edit-toggle" data-product-id="' . esc_attr($item['product_id']) . '">'
+					. esc_html__('Quick Edit', 'intersoccer-product-variations') . '</button>';
+
+				$qe_panel = '<div class="intersoccer-pm-quick-edit" data-product-id="' . esc_attr($item['product_id']) . '" data-type="' . esc_attr($item['type']) . '" style="display:none;margin-top:8px;padding:10px;background:#f6f7f7;border:1px solid #ccd0d4;max-width:560px;">'
+					. '<p><label>' . esc_html__('Name', 'intersoccer-product-variations') . ' <input type="text" class="pm-qe-name widefat" value="' . esc_attr($item['name']) . '" /></label></p>'
+					. '<p><label>' . esc_html__('Status', 'intersoccer-product-variations') . ' <select class="pm-qe-status">'
+					. '<option value="draft"' . selected($item['status'], 'draft', false) . '>Draft</option>'
+					. '<option value="publish"' . selected($item['status'], 'publish', false) . '>Publish</option>'
+					. '<option value="private"' . selected($item['status'], 'private', false) . '>Private</option>'
+					. '</select></label></p>'
+					. $render_multi('pa_program-season', 'pm-qe-season', __('Season', 'intersoccer-product-variations'))
+					. $render_multi('pa_intersoccer-venues', 'pm-qe-venues', __('Venues', 'intersoccer-product-variations'));
+				if ($item['type'] === 'camp') {
+					$qe_panel .= $render_multi('pa_camp-terms', 'pm-qe-camp-terms', __('Camp Terms', 'intersoccer-product-variations'))
+						. $render_multi('pa_camp-times', 'pm-qe-camp-times', __('Camp Times', 'intersoccer-product-variations'));
+				}
+				$qe_panel .= '<p><button type="button" class="button button-primary intersoccer-pm-quick-edit-save" data-product-id="' . esc_attr($item['product_id']) . '">'
+					. esc_html__('Update', 'intersoccer-product-variations') . '</button> '
+					. '<button type="button" class="button intersoccer-pm-quick-edit-cancel">' . esc_html__('Cancel', 'intersoccer-product-variations') . '</button> '
+					. '<span class="pm-qe-status-msg"></span></p></div>';
+
+				return $qe . ' '
+					. '<a href="' . esc_url($detail_url) . '" class="button button-small">' . esc_html__('Manage', 'intersoccer-product-variations') . '</a> '
 					. '<a href="' . esc_url($dup_url) . '" class="button button-small">' . esc_html__('Duplicate', 'intersoccer-product-variations') . '</a> '
-					. '<a href="' . esc_url($edit_url) . '" class="button button-small button-link">' . esc_html__('WC Edit', 'intersoccer-product-variations') . '</a>';
+					. '<a href="' . esc_url($edit_url) . '" class="button button-small button-link">' . esc_html__('WC Edit', 'intersoccer-product-variations') . '</a>'
+					. $qe_panel;
 
 			default:
 				return '';

--- a/intersoccer-product-variations.php
+++ b/intersoccer-product-variations.php
@@ -3,7 +3,7 @@
  * Plugin Name: InterSoccer Product Variations
  * Description: Enhanced WooCommerce product variations with dynamic pricing, AJAX updates, and Elementor integration for InterSoccer camps and courses.
  * Author: Jeremy Lee
- * Version: 2.7.17
+ * Version: 2.7.18
  * License: GPL v2 or later
  * Text Domain: intersoccer-product-variations
  * Domain Path: /languages
@@ -330,6 +330,8 @@ $includes = [
     'includes/woocommerce/product-types.php',
     'includes/woocommerce/product-course.php',
     'includes/woocommerce/product-camp.php',
+    'includes/woocommerce/camp-schedule.php',
+    'includes/woocommerce/camp-schedule-migrate.php',
     'includes/woocommerce/discounts.php',
     'includes/woocommerce/cart-calculations.php',
     'includes/woocommerce/checkout-calculations.php',

--- a/js/program-manager.js
+++ b/js/program-manager.js
@@ -87,6 +87,12 @@
 	function buildMatrixPreview() {
 		var type = getSelectedType();
 		var rows = Matrix[type] || [];
+
+		if (type === 'camp') {
+			rows = rebuildCampMatrixFromParentAttrs();
+			Matrix.camp = rows;
+		}
+
 		var $container = $('#intersoccer-pm-matrix-container');
 		$container.empty();
 
@@ -105,6 +111,84 @@
 		}
 		html += '</tbody></table>';
 		$container.html(html);
+	}
+
+	/**
+	 * Rebuild camp matrix from selected parent ages/times (pairs Full/Half Day with clock hours).
+	 */
+	function rebuildCampMatrixFromParentAttrs() {
+		var defaults = window.intersoccerPMCampDefaults || {
+			ages: ['5-13y-full-day', '3-5y-half-day'],
+			bookings: ['full-week', 'single-days'],
+			times: ['1000-1700', '1000-1230']
+		};
+		var ages = getSelectedAttrSlugs('pa_age-group');
+		var times = getSelectedAttrSlugs('pa_camp-times');
+		if (!ages.length) {
+			ages = defaults.ages.slice();
+		}
+		if (!times.length) {
+			times = defaults.times.slice();
+		}
+		var bookings = defaults.bookings.slice();
+		var bookingLabels = {
+			'full-week': 'Full Week',
+			'single-days': 'Single Day(s)'
+		};
+		var rows = [];
+		ages.forEach(function(age) {
+			var time = pairCampTimeForAge(age, times);
+			bookings.forEach(function(booking) {
+				var row = {
+					'pa_booking-type': booking,
+					'pa_age-group': age
+				};
+				var parts = [bookingLabels[booking] || booking, age];
+				if (time) {
+					row['pa_camp-times'] = time;
+					parts.push(time);
+				}
+				row.label = parts.join(' / ');
+				rows.push(row);
+			});
+		});
+		return rows;
+	}
+
+	function getSelectedAttrSlugs(taxonomy) {
+		var $select = $('.intersoccer-pm-attr-row:visible select[data-taxonomy="' + taxonomy + '"]');
+		if (!$select.length) {
+			return [];
+		}
+		var vals = $select.val();
+		if (!vals) {
+			return [];
+		}
+		return Array.isArray(vals) ? vals.filter(Boolean) : [vals].filter(Boolean);
+	}
+
+	function pairCampTimeForAge(ageSlug, allowedTimes) {
+		var age = (ageSlug || '').toLowerCase();
+		var isHalf = age.indexOf('half-day') !== -1 || age.indexOf('half_day') !== -1;
+		var preferred = isHalf
+			? ['1000-1230', '1000-1200', '0900-1200']
+			: ['1000-1700', '1000-1500', '0900-1700'];
+		var pool = (allowedTimes && allowedTimes.length) ? allowedTimes : preferred;
+		for (var i = 0; i < preferred.length; i++) {
+			if (pool.indexOf(preferred[i]) !== -1) {
+				return preferred[i];
+			}
+		}
+		for (var j = 0; j < pool.length; j++) {
+			var s = String(pool[j]).toLowerCase();
+			if (isHalf && (/12[0-3]0$/.test(s) || s.indexOf('1230') !== -1 || s.indexOf('1200') !== -1)) {
+				return pool[j];
+			}
+			if (!isHalf && (/17[0-3]0$/.test(s) || s.indexOf('1700') !== -1 || s.indexOf('1500') !== -1)) {
+				return pool[j];
+			}
+		}
+		return (allowedTimes && allowedTimes.length) ? '' : (isHalf ? '1000-1230' : '1000-1700');
 	}
 
 	// =========================================================================
@@ -536,6 +620,177 @@
 			e.preventDefault();
 			$(this).closest('.intersoccer-pm-add-term-form').find('.intersoccer-pm-add-term-btn').trigger('click');
 		}
+	});
+
+	// =========================================================================
+	// Camp schedule editing (detail view)
+	// =========================================================================
+
+	var scheduleTimer = null;
+
+	function saveCampSchedule($row) {
+		var variationId = $row.data('variation-id');
+		var $status = $row.find('.intersoccer-pm-schedule-status');
+		$status.text(PM.i18n.saving).css('color', '#666');
+
+		$.post(PM.ajax_url, {
+			action: 'intersoccer_pm_save_camp_schedule',
+			nonce: PM.nonce,
+			variation_id: variationId,
+			week: $row.find('.intersoccer-pm-camp-week').val(),
+			start: $row.find('.intersoccer-pm-camp-start').val(),
+			end: $row.find('.intersoccer-pm-camp-end').val()
+		}).done(function(response) {
+			if (response.success) {
+				$status.text(PM.i18n.saved).css('color', 'green');
+				setTimeout(function() { $status.text(''); }, 2000);
+			} else {
+				$status.text(PM.i18n.error).css('color', 'red');
+			}
+		}).fail(function() {
+			$status.text(PM.i18n.error).css('color', 'red');
+		});
+	}
+
+	$(document).on('change', '.intersoccer-pm-camp-week, .intersoccer-pm-camp-start, .intersoccer-pm-camp-end', function() {
+		var $row = $(this).closest('tr');
+		if (scheduleTimer) clearTimeout(scheduleTimer);
+		scheduleTimer = setTimeout(function() {
+			saveCampSchedule($row);
+		}, 400);
+	});
+
+	$(document).on('click', '#intersoccer-pm-propose-weeks-btn', function() {
+		var $btn = $(this);
+		var productId = $btn.data('product-id');
+		var week1 = $('#intersoccer-pm-week1-start').val();
+		var duration = parseInt($('#intersoccer-pm-week-duration').val(), 10) || 5;
+		var $status = $('#intersoccer-pm-schedule-tools-status');
+
+		if (!week1) {
+			alert('Please set Week 1 start date.');
+			return;
+		}
+
+		$status.text(PM.i18n.saving).css('color', '#666');
+		$.post(PM.ajax_url, {
+			action: 'intersoccer_pm_prefill_camp_schedules',
+			nonce: PM.nonce,
+			product_id: productId,
+			week1_start: week1,
+			duration_days: duration,
+			overwrite: 0
+		}).done(function(response) {
+			if (!response.success) {
+				$status.text(response.data && response.data.message ? response.data.message : PM.i18n.error).css('color', 'red');
+				return;
+			}
+			(response.data.rows || []).forEach(function(row) {
+				var $tr = $('tr[data-variation-id="' + row.variation_id + '"]');
+				if (!$tr.length || !row.schedule) return;
+				$tr.find('.intersoccer-pm-camp-week').val(row.schedule.week || '');
+				$tr.find('.intersoccer-pm-camp-start').val(row.schedule.start || '');
+				$tr.find('.intersoccer-pm-camp-end').val(row.schedule.end || '');
+			});
+			$status.text('Updated ' + (response.data.updated || 0) + ' variations.').css('color', 'green');
+		}).fail(function() {
+			$status.text(PM.i18n.error).css('color', 'red');
+		});
+	});
+
+	$(document).on('click', '#intersoccer-pm-apply-parsed-dates-btn', function() {
+		var $btn = $(this);
+		var productId = $btn.data('product-id');
+		var $status = $('#intersoccer-pm-schedule-tools-status');
+		if (!confirm('Seed empty camp dates from camp-terms parsing? Existing dates will not be overwritten.')) {
+			return;
+		}
+		$status.text(PM.i18n.saving).css('color', '#666');
+		$.post(PM.ajax_url, {
+			action: 'intersoccer_pm_apply_parsed_camp_dates',
+			nonce: PM.nonce,
+			product_id: productId,
+			force: 0
+		}).done(function(response) {
+			if (!response.success) {
+				$status.text(response.data && response.data.message ? response.data.message : PM.i18n.error).css('color', 'red');
+				return;
+			}
+			$status.text('Updated ' + (response.data.updated || 0) + ', skipped ' + (response.data.skipped || 0) + ', failed ' + (response.data.failed || 0) + '. Reloading…').css('color', 'green');
+			setTimeout(function() { window.location.reload(); }, 1200);
+		}).fail(function() {
+			$status.text(PM.i18n.error).css('color', 'red');
+		});
+	});
+
+	$(document).on('click', '#intersoccer-pm-propose-times-btn', function() {
+		var $btn = $(this);
+		var productId = $btn.data('product-id');
+		var $status = $('#intersoccer-pm-schedule-tools-status');
+		$status.text(PM.i18n.saving).css('color', '#666');
+		$.post(PM.ajax_url, {
+			action: 'intersoccer_pm_propose_camp_times',
+			nonce: PM.nonce,
+			product_id: productId,
+			overwrite: 0
+		}).done(function(response) {
+			if (!response.success) {
+				$status.text(response.data && response.data.message ? response.data.message : PM.i18n.error).css('color', 'red');
+				return;
+			}
+			$status.text(response.data.message || ('Updated ' + (response.data.updated || 0))).css('color', 'green');
+			setTimeout(function() { window.location.reload(); }, 1000);
+		}).fail(function() {
+			$status.text(PM.i18n.error).css('color', 'red');
+		});
+	});
+
+	// =========================================================================
+	// List quick edit
+	// =========================================================================
+
+	$(document).on('click', '.intersoccer-pm-quick-edit-toggle', function() {
+		var id = $(this).data('product-id');
+		$('.intersoccer-pm-quick-edit').hide();
+		$('.intersoccer-pm-quick-edit[data-product-id="' + id + '"]').show();
+	});
+
+	$(document).on('click', '.intersoccer-pm-quick-edit-cancel', function() {
+		$(this).closest('.intersoccer-pm-quick-edit').hide();
+	});
+
+	$(document).on('click', '.intersoccer-pm-quick-edit-save', function() {
+		var $btn = $(this);
+		var productId = $btn.data('product-id');
+		var $panel = $btn.closest('.intersoccer-pm-quick-edit');
+		var $msg = $panel.find('.pm-qe-status-msg');
+		var attrs = {
+			'pa_program-season': $panel.find('.pm-qe-season').val() || [],
+			'pa_intersoccer-venues': $panel.find('.pm-qe-venues').val() || []
+		};
+		if ($panel.data('type') === 'camp') {
+			attrs['pa_camp-terms'] = $panel.find('.pm-qe-camp-terms').val() || [];
+			attrs['pa_camp-times'] = $panel.find('.pm-qe-camp-times').val() || [];
+		}
+
+		$msg.text(PM.i18n.saving).css('color', '#666');
+		$.post(PM.ajax_url, {
+			action: 'intersoccer_pm_quick_edit',
+			nonce: PM.nonce,
+			product_id: productId,
+			name: $panel.find('.pm-qe-name').val(),
+			status: $panel.find('.pm-qe-status').val(),
+			attrs: attrs
+		}).done(function(response) {
+			if (response.success) {
+				$msg.text(PM.i18n.saved).css('color', 'green');
+				setTimeout(function() { window.location.reload(); }, 800);
+			} else {
+				$msg.text(response.data && response.data.message ? response.data.message : PM.i18n.error).css('color', 'red');
+			}
+		}).fail(function() {
+			$msg.text(PM.i18n.error).css('color', 'red');
+		});
 	});
 
 	// =========================================================================

--- a/tests/AttributeRegistryTest.php
+++ b/tests/AttributeRegistryTest.php
@@ -102,7 +102,22 @@ class AttributeRegistryTest extends TestCase {
 
         $camp_keys = intersoccer_attr_health_required_keys('camp');
         $this->assertContains('pa_booking-type', $camp_keys);
+        $this->assertContains('pa_age-group', $camp_keys);
+        $this->assertContains('pa_camp-times', $camp_keys);
+        $this->assertContains('_camp_start_date', $camp_keys);
+        $this->assertContains('_camp_end_date', $camp_keys);
+        $this->assertContains('_camp_week_index', $camp_keys);
         $this->assertNotContains('pa_course-day', $camp_keys);
+    }
+
+    public function test_camp_variation_template_includes_camp_times() {
+        $templates = intersoccer_attr_product_type_templates();
+        $this->assertContains('camp-times', $templates['camp']['variation']);
+        $this->assertContains('camp-times', $templates['camp']['parent']);
+        $terms = intersoccer_attr_definition('camp-times')['default_terms'] ?? [];
+        $slugs = array_column($terms, 'slug');
+        $this->assertContains('1000-1700', $slugs);
+        $this->assertContains('1000-1230', $slugs);
     }
 
     public function test_camp_and_course_templates_include_girls_only() {

--- a/tests/CampScheduleTest.php
+++ b/tests/CampScheduleTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Camp schedule meta helpers (source of truth + deprecated terms fallback).
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class CampScheduleTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		if (class_exists('MockMetaData')) {
+			MockMetaData::reset();
+		}
+		require_once dirname(__DIR__) . '/includes/woocommerce/attribute-registry.php';
+		require_once dirname(__DIR__) . '/includes/woocommerce/camp-schedule.php';
+		if (!function_exists('intersoccer_parse_camp_week_from_terms')) {
+			require_once dirname(__DIR__) . '/includes/woocommerce/discounts.php';
+		}
+	}
+
+	public function test_camp_template_requires_schedule_meta() {
+		$meta = intersoccer_attr_required('camp', 'meta');
+		$this->assertContains('_camp_start_date', $meta);
+		$this->assertContains('_camp_end_date', $meta);
+		$this->assertContains('_camp_week_index', $meta);
+
+		$health = intersoccer_attr_health_required_keys('camp');
+		$this->assertContains('_camp_start_date', $health);
+		$this->assertContains('pa_booking-type', $health);
+		$this->assertContains('pa_camp-times', $health);
+	}
+
+	public function test_get_camp_schedule_prefers_meta_over_terms() {
+		$vid = 9001;
+		intersoccer_update_camp_schedule($vid, '2026-07-06', '2026-07-10', 3, true);
+
+		$schedule = intersoccer_get_camp_schedule($vid, true);
+		$this->assertSame('2026-07-06', $schedule['start']);
+		$this->assertSame('2026-07-10', $schedule['end']);
+		$this->assertSame(3, $schedule['week']);
+		$this->assertSame('meta', $schedule['source']);
+	}
+
+	public function test_propose_from_week1_offsets_by_seven_days() {
+		$w1 = intersoccer_camp_schedule_propose_from_week1('2026-06-29', 1, 5);
+		$this->assertSame('2026-06-29', $w1['start']);
+		$this->assertSame('2026-07-03', $w1['end']);
+
+		$w2 = intersoccer_camp_schedule_propose_from_week1('2026-06-29', 2, 5);
+		$this->assertSame('2026-07-06', $w2['start']);
+		$this->assertSame('2026-07-10', $w2['end']);
+
+		$easter = intersoccer_camp_schedule_propose_from_week1('2026-03-30', 1, 4);
+		$this->assertSame('2026-03-30', $easter['start']);
+		$this->assertSame('2026-04-02', $easter['end']);
+	}
+
+	public function test_deprecated_terms_parse_extracts_week_and_duration() {
+		$parsed = intersoccer_camp_schedule_from_terms_deprecated(
+			'Summer Week 2: July 6-10 (5 days)',
+			'Summer Camps 2026'
+		);
+		$this->assertSame(2, $parsed['week']);
+		// Start/end may come from RR helper or PV start+duration; week is reliable here.
+		$this->assertSame('terms_parse', $parsed['source']);
+	}
+
+	public function test_migrate_dry_run_shape_without_wc_product() {
+		require_once dirname(__DIR__) . '/includes/woocommerce/camp-schedule-migrate.php';
+		$result = intersoccer_migrate_camp_dates_for_product(0, ['dry_run' => true]);
+		$this->assertInstanceOf(WP_Error::class, $result);
+	}
+}

--- a/tests/CampTimeAgePairingTest.php
+++ b/tests/CampTimeAgePairingTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Camp time ↔ age pairing helper tests.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class CampTimeAgePairingTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		require_once dirname(__DIR__) . '/includes/helpers.php';
+	}
+
+	public function test_full_day_age_maps_to_1000_1700() {
+		$this->assertSame(
+			'1000-1700',
+			intersoccer_pm_default_camp_time_slug_for_age('5-13y-full-day')
+		);
+	}
+
+	public function test_half_day_age_maps_to_1000_1230() {
+		$this->assertSame(
+			'1000-1230',
+			intersoccer_pm_default_camp_time_slug_for_age('3-5y-half-day')
+		);
+	}
+
+	public function test_prefers_allowed_pool_match() {
+		$this->assertSame(
+			'1000-1500',
+			intersoccer_pm_default_camp_time_slug_for_age('5-13y-full-day', ['1000-1500', '1000-1230'])
+		);
+		$this->assertSame(
+			'1000-1230',
+			intersoccer_pm_default_camp_time_slug_for_age('3-5y-half-day', ['1000-1700', '1000-1230'])
+		);
+	}
+
+	public function test_empty_when_allowed_pool_has_no_safe_match() {
+		$this->assertSame(
+			'',
+			intersoccer_pm_default_camp_time_slug_for_age('3-5y-half-day', ['0800-0900', '1400-1600'])
+		);
+	}
+
+	public function test_heuristic_matches_end_hour_in_allowed() {
+		$this->assertSame(
+			'0930-1230',
+			intersoccer_pm_default_camp_time_slug_for_age('3-5y-half-day', ['0930-1230', '0930-1700'])
+		);
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -417,6 +417,16 @@ if (!function_exists('update_post_meta')) {
     }
 }
 
+if (!function_exists('delete_post_meta')) {
+    function delete_post_meta($post_id, $key) {
+        if (class_exists('MockMetaData') && isset(MockMetaData::$data[$post_id][$key])) {
+            unset(MockMetaData::$data[$post_id][$key]);
+            return true;
+        }
+        return true;
+    }
+}
+
 if (!function_exists('update_postmeta_cache')) {
     function update_postmeta_cache($post_ids, $force = true) {
         return true;


### PR DESCRIPTION
Store week/start/end on variations, pair Full/Half Day ages with catalogue times in Program Manager, and keep age-group multi-select on the parent for scaffolding.