### PR TITLE
Bump Product Variations to 2.7.20 for the July 20 cut.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 This plugin enhances the WooCommerce booking system for InterSoccer Switzerland by managing complex product variations, dynamic pricing calculations, and sophisticated sibling discount systems. It supports three main product types: Camps (full-week and single-day), Courses (seasonal with prorated pricing), and Birthdays, with comprehensive admin interfaces and multilingual support.
 
 ## Version
-- **Version: 2.7.18**
-- Release Date: July 19, 2026
+- **Version: 2.7.20**
+- Release Date: July 20, 2026
 
-## Camp schedule meta (2.7.18)
+## Camp schedule meta (2.7.18+)
 
 Camp variations store `_camp_start_date`, `_camp_end_date`, and `_camp_week_index`. Program Manager can edit/pre-fill these and seed them from camp-terms via `wp intersoccer migrate-camp-dates`. Parsing dates from `pa_camp-terms` remains a **deprecated fallback** during migration — see `scratch/BACKLOG-remove-camp-terms-date-parse.md` and `.cursor/rules/camp-date-meta.mdc`.
 

--- a/includes/woocommerce/program-manager.php
+++ b/includes/woocommerce/program-manager.php
@@ -67,7 +67,7 @@ class InterSoccer_Program_Manager {
 			'intersoccer-program-manager',
 			INTERSOCCER_PRODUCT_VARIATIONS_PLUGIN_URL . 'js/program-manager.js',
 			['jquery'],
-			'1.2.0',
+			'2.7.20',
 			true
 		);
 

--- a/intersoccer-product-variations.php
+++ b/intersoccer-product-variations.php
@@ -3,7 +3,7 @@
  * Plugin Name: InterSoccer Product Variations
  * Description: Enhanced WooCommerce product variations with dynamic pricing, AJAX updates, and Elementor integration for InterSoccer camps and courses.
  * Author: Jeremy Lee
- * Version: 2.7.18
+ * Version: 2.7.20
  * License: GPL v2 or later
  * Text Domain: intersoccer-product-variations
  * Domain Path: /languages


### PR DESCRIPTION
Align the plugin header and README with the calendar release date, and refresh the Program Manager script cache-buster.