### PR TITLE
Unify Order Meta Repair and prune legacy twin meta.

### DIFF
--- a/docs/ORDER-META-CONTRACT.md
+++ b/docs/ORDER-META-CONTRACT.md
@@ -17,16 +17,36 @@ Deprecated keys (strip on repair): `Variation ID`, `Base Price`, `Remaining Sess
 ## Write path
 
 1. Checkout: `intersoccer_write_order_line_meta()` with `mode => checkout`
-2. Repair: Find Order Issues → `intersoccer_write_order_line_meta()` with `mode => repair`
+2. Repair: WooCommerce → **Order Meta Repair** → `intersoccer_update_order_metadata()` → `intersoccer_write_order_line_meta()` with `mode => repair`
 3. Admin player assignment: direct meta updates on order items
 
 Repair is **add-only** for most keys. **Correctable** when empty: Activity Type, Attendee DOB, Attendee Gender, Medical Conditions, **`assigned_player_id`**.
 
+Optional repair flags (Scan & preview and Automated batch share the same options):
+
+| Flag | Behavior |
+|------|----------|
+| `strip_deprecated` | Removes deprecated keys listed above when `assigned_player` is present |
+| `prune_legacy_twins` (default **ON** in admin UI) | Collapses same-key duplicate rows; deletes reverse-map legacy labels when the EN canonical key is already present |
+
+### Twin meta: prune A–C, keep D
+
+| Class | Example | On prune |
+|-------|---------|----------|
+| **A** same-key multi-row | two `Activity Type` rows | Collapse to one value |
+| **B** `wc_label` vs `order_meta_label` | `InterSoccer Venues` + `Sites InterSoccer` | Delete legacy (`InterSoccer Venues`) |
+| **C** EN vs FR/DE label | `Lieux InterSoccer` when `Sites InterSoccer` present | Delete FR/DE legacy |
+| **D** intentional dual-write | display label + `pa_*` / `attribute_pa_*` / `_camp_*` / `_intersoccer_canonical_*` | **Keep** (not bugs) |
+
+Soft migrate (`intersoccer_normalize_legacy_order_meta_keys`) still runs without prune: it renames legacy → canonical only when the canonical key is empty. Prune (`intersoccer_prune_legacy_order_meta_twins`) additionally deletes remaining reverse-map twins.
+
+Legacy admin URLs `intersoccer-update-orders` and `intersoccer-automated-updates` redirect to `intersoccer-order-meta-repair` (`tab=scan` / `tab=batch`).
+
 ## Historical migration playbook
 
 1. **Player Management → Advanced → Backfill Player IDs** — assign `player_id` UUID to existing `intersoccer_players` rows.
-2. **Product Variations → Find Order Issues** — repair order lines; resolves `assigned_player_id` from live PM data when only legacy `assigned_player` index exists.
-3. **Reports & Rosters → Reconcile Rosters** — refresh roster DB for affected date range.
+2. **Product Variations → WooCommerce → Order Meta Repair** — Scan & preview or Automated batch (prune ON); resolves `assigned_player_id` from live PM data when only legacy `assigned_player` index exists.
+3. **Reports & Rosters → Reconcile Rosters** — refresh roster DB for affected date range (separate post-step; RR code unchanged).
 
 Dual-write during transition: new checkouts write both `assigned_player_id` and legacy `assigned_player`. Readers (RR `PlayerMatcher`) prefer UUID, then index fallback.
 
@@ -34,11 +54,17 @@ Dual-write during transition: new checkouts write both `assigned_player_id` and 
 
 | Tool | Scope |
 |------|--------|
-| **Variation Health** | Product catalog attributes only; does not change orders |
-| **Find Order Issues** | Order item meta repair from product/cart contract |
-| **Reconcile Rosters** | Sync roster DB from order meta |
+| **Variation Health** | Product catalog attributes only; does not change orders (Program Manager) |
+| **Order Meta Repair** | Order item meta repair from product/cart contract (scan + automated batch) |
+| **Reconcile Rosters** | Sync roster DB from order meta (reports-rosters) |
 
 After meta repair, `intersoccer_order_line_meta_repaired` triggers a targeted roster refresh in reports-rosters.
+
+## PV writers vs RR readers
+
+- **Writers (PV)** prefer EN canonical display labels (`Sites InterSoccer`, `Booking Type`, …) plus language-neutral `_intersoccer_canonical_*` / `_camp_*` dual-write targets.
+- **Readers (RR)** keep dual-read aliases in `order-meta-keys.php` (FR/DE / wc_label fallbacks) so historical lines still resolve until repaired.
+- Consistency rule: if RR already aliases a key that checkout/repair never writes, add the dual-write in PV only — do not remove RR aliases in this cut.
 
 ## SQL report keys (Final Reports)
 

--- a/includes/woocommerce/admin-ui.php
+++ b/includes/woocommerce/admin-ui.php
@@ -15,6 +15,8 @@ if (!function_exists('intersoccer_get_default_discount_rules')) {
     require_once INTERSOCCER_PRODUCT_VARIATIONS_PLUGIN_DIR . 'includes/woocommerce/discounts.php';
 }
 
+require_once INTERSOCCER_PRODUCT_VARIATIONS_PLUGIN_DIR . 'includes/woocommerce/order-meta-repair-admin.php';
+
 add_action('admin_init', 'intersoccer_bootstrap_discount_defaults');
 function intersoccer_bootstrap_discount_defaults() {
     $existing = get_option('intersoccer_discount_rules', []);
@@ -26,7 +28,7 @@ function intersoccer_bootstrap_discount_defaults() {
 }
 
 /**
- * Register admin submenu for Discounts, Update Orders, and Variation Health Checker.
+ * Register admin submenu for Discounts and Order Meta Repair.
  */
 add_action('admin_menu', 'intersoccer_add_admin_submenus');
 function intersoccer_add_admin_submenus() {
@@ -40,30 +42,59 @@ function intersoccer_add_admin_submenus() {
         'intersoccer_render_discounts_page'
     );
 
-    // Update Orders submenu
     add_submenu_page(
         'woocommerce',
-        __('Scan Orders missing data', 'intersoccer-product-variations'),
-        __('Find Order Issues', 'intersoccer-product-variations'),
+        __('Order Meta Repair', 'intersoccer-product-variations'),
+        __('Order Meta Repair', 'intersoccer-product-variations'),
         'manage_woocommerce',
-        'intersoccer-update-orders',
-        'intersoccer_render_update_orders_page',
+        intersoccer_order_meta_repair_page_slug(),
+        'intersoccer_render_order_meta_repair_page',
         2
     );
 
     // Variation Health Checker — merged into Program Manager; submenu removed.
-    // The render function and AJAX handlers remain for backward compatibility.
+    // Find Order Issues + Bulk Repair — merged into Order Meta Repair above.
 
-    add_submenu_page(
-        'woocommerce',
-        __('Bulk Repair Order Details', 'intersoccer-product-variations'),
-        __('Bulk Repair Order', 'intersoccer-product-variations'),
-        'manage_woocommerce',
-        'intersoccer-automated-updates',
-        'intersoccer_render_automated_update_orders_page',
-    );
+    intersoccer_debug('InterSoccer: Registered admin submenus including Order Meta Repair');
+}
 
-    intersoccer_debug('InterSoccer: Registered admin submenus including Variation Health Checker');
+add_action('admin_init', 'intersoccer_redirect_legacy_order_meta_repair_pages');
+
+/**
+ * Unified Order Meta Repair admin page (Scan + Automated batch tabs).
+ */
+function intersoccer_render_order_meta_repair_page() {
+    if (!current_user_can('manage_woocommerce')) {
+        wp_die(__('You do not have permission to access this page.', 'intersoccer-product-variations'));
+    }
+
+    $tab = isset($_GET['tab']) ? sanitize_key(wp_unslash((string) $_GET['tab'])) : 'scan';
+    if (!in_array($tab, ['scan', 'batch'], true)) {
+        $tab = 'scan';
+    }
+
+    $base_url = admin_url('admin.php?page=' . intersoccer_order_meta_repair_page_slug());
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e('Order Meta Repair', 'intersoccer-product-variations'); ?></h1>
+        <p><?php esc_html_e('Scan orders for missing or twin metadata, then repair selected rows or run an automated batch. After repair, run Reports → Reconcile Rosters if needed.', 'intersoccer-product-variations'); ?></p>
+        <nav class="nav-tab-wrapper" style="margin-bottom: 16px;">
+            <a href="<?php echo esc_url(add_query_arg('tab', 'scan', $base_url)); ?>" class="nav-tab <?php echo $tab === 'scan' ? 'nav-tab-active' : ''; ?>">
+                <?php esc_html_e('Scan &amp; preview', 'intersoccer-product-variations'); ?>
+            </a>
+            <a href="<?php echo esc_url(add_query_arg('tab', 'batch', $base_url)); ?>" class="nav-tab <?php echo $tab === 'batch' ? 'nav-tab-active' : ''; ?>">
+                <?php esc_html_e('Automated batch', 'intersoccer-product-variations'); ?>
+            </a>
+        </nav>
+        <?php
+        if ($tab === 'batch') {
+            intersoccer_render_automated_update_orders_page(true);
+        } else {
+            intersoccer_render_update_orders_page(true);
+        }
+        ?>
+    </div>
+    <?php
 }
 
 /**
@@ -1155,11 +1186,12 @@ class InterSoccer_Order_Preview_Table extends WP_List_Table {
 /**
  * Modified intersoccer_render_update_orders_page
  */
-function intersoccer_render_update_orders_page() {
+function intersoccer_render_update_orders_page($embedded = false) {
     if (!current_user_can('manage_woocommerce')) {
         wp_die(__('You do not have permission to access this page.', 'intersoccer-product-variations'));
     }
 
+    $page_slug = intersoccer_order_meta_repair_page_slug();
     $message = '';
     $selected_statuses = isset($_REQUEST['order_statuses']) && is_array($_REQUEST['order_statuses'])
         ? array_values(array_map('sanitize_text_field', $_REQUEST['order_statuses']))
@@ -1167,6 +1199,8 @@ function intersoccer_render_update_orders_page() {
     $preview_limit_value = isset($_REQUEST['preview_limit']) ? sanitize_text_field((string) $_REQUEST['preview_limit']) : '25';
     $fix_activity_type_only_checked = isset($_REQUEST['fix_activity_type_only']) && (string) $_REQUEST['fix_activity_type_only'] === '1';
     $strip_deprecated_checked = isset($_REQUEST['strip_deprecated_meta']) && (string) $_REQUEST['strip_deprecated_meta'] === '1';
+    // Aggressive twin prune defaults ON for the unified tool.
+    $prune_legacy_twins_checked = !isset($_REQUEST['prune_legacy_twins']) || (string) $_REQUEST['prune_legacy_twins'] === '1';
     $show_preview = isset($_REQUEST['preview_updates']) || isset($_REQUEST['detailed_preview']);
     $show_detailed = isset($_REQUEST['detailed_preview']);
 
@@ -1178,12 +1212,14 @@ function intersoccer_render_update_orders_page() {
     // Preserve preview state/filters across pagination links by redirecting preview POST to GET.
     if ($_SERVER['REQUEST_METHOD'] === 'POST' && (isset($_POST['preview_updates']) || isset($_POST['detailed_preview']))) {
         $query_args = [
-            'page' => 'intersoccer-update-orders',
+            'page' => $page_slug,
+            'tab' => 'scan',
             'preview_updates' => isset($_POST['preview_updates']) ? '1' : null,
             'detailed_preview' => isset($_POST['detailed_preview']) ? '1' : null,
             'preview_limit' => $preview_limit_value,
             'fix_activity_type_only' => $fix_activity_type_only_checked ? '1' : '0',
             'strip_deprecated_meta' => $strip_deprecated_checked ? '1' : '0',
+            'prune_legacy_twins' => $prune_legacy_twins_checked ? '1' : '0',
             'order_statuses' => $selected_statuses,
         ];
         $query_args = array_filter($query_args, static function ($value) {
@@ -1203,10 +1239,11 @@ function intersoccer_render_update_orders_page() {
         
         $fix_activity_type_only = isset($_POST['fix_activity_type_only']) && $_POST['fix_activity_type_only'] === '1';
         $strip_deprecated = isset($_POST['strip_deprecated_meta']) && $_POST['strip_deprecated_meta'] === '1';
+        $prune_legacy_twins = !isset($_POST['prune_legacy_twins']) || $_POST['prune_legacy_twins'] === '1';
 
         foreach ($order_ids as $order_id) {
             $order = wc_get_order($order_id);
-            if ($order && intersoccer_update_order_metadata($order, $fix_activity_type_only, $strip_deprecated)) {
+            if ($order && intersoccer_update_order_metadata($order, $fix_activity_type_only, $strip_deprecated, $prune_legacy_twins)) {
                 $updated_count++;
             } else {
                 $errors[] = $order_id;
@@ -1223,9 +1260,14 @@ function intersoccer_render_update_orders_page() {
     }
 
     ?>
+    <?php if (!$embedded) : ?>
     <div class="wrap">
         <h1><?php _e('Order Metadata Update Tool', 'intersoccer-product-variations'); ?></h1>
         <p><?php _e('Find and update orders that are missing metadata fields needed for accurate rosters and reports.', 'intersoccer-product-variations'); ?></p>
+    <?php else : ?>
+        <h2><?php esc_html_e('Scan &amp; preview', 'intersoccer-product-variations'); ?></h2>
+        <p><?php esc_html_e('Find orders with missing metadata or label twins, preview proposed fixes, then update selected orders.', 'intersoccer-product-variations'); ?></p>
+    <?php endif; ?>
         
         <?php if ($message) : ?>
             <div class="updated notice"><p><?php echo esc_html($message); ?></p></div>
@@ -1233,6 +1275,8 @@ function intersoccer_render_update_orders_page() {
 
         <!-- Configuration Form -->
         <form method="post" id="preview-orders-form">
+            <input type="hidden" name="page" value="<?php echo esc_attr($page_slug); ?>" />
+            <input type="hidden" name="tab" value="scan" />
             <table class="form-table">
                 <tr>
                     <th scope="row"><?php _e('Order Statuses to Check', 'intersoccer-product-variations'); ?></th>
@@ -1273,6 +1317,13 @@ function intersoccer_render_update_orders_page() {
                         </label>
                         <p class="description">
                             <?php _e('Removes Variation ID, Base Price, Remaining Sessions, and Player Index keys when assigned_player is present.', 'intersoccer-product-variations'); ?>
+                        </p>
+                        <label>
+                            <input type="checkbox" name="prune_legacy_twins" value="1" <?php checked($prune_legacy_twins_checked); ?>>
+                            <?php _e('Prune legacy label twins', 'intersoccer-product-variations'); ?>
+                        </label>
+                        <p class="description">
+                            <?php _e('Removes WC/FR/DE label twins when the English canonical key is present (e.g. InterSoccer Venues when Sites InterSoccer exists). Does not remove pa_* slug twins.', 'intersoccer-product-variations'); ?>
                         </p>
                     </td>
                 </tr>
@@ -1316,9 +1367,13 @@ function intersoccer_render_update_orders_page() {
                 $total_orders_scanned = count($table->all_items);  // We'll need to track this
                 $orders_with_missing = count($table->all_items);   // Orders that have missing metadata
                 $total_missing_items = 0;
+                $all_low_risk_ids = [];
                 foreach ($table->all_items as $order_data) {
                     foreach ($order_data['missing_keys'] as $item_missing) {
                         $total_missing_items += count($item_missing);
+                    }
+                    if (($order_data['risk_level'] ?? '') === 'low') {
+                        $all_low_risk_ids[] = (int) $order_data['order_id'];
                     }
                 }
                 ?>
@@ -1339,7 +1394,7 @@ function intersoccer_render_update_orders_page() {
                 <form method="post" id="bulk-update-form">
                     <div class="tablenav top">
                         <div class="alignleft actions">
-                            <button type="button" id="select-all-low-risk" class="button"><?php _e('Select All Low Risk', 'intersoccer-product-variations'); ?></button>
+                            <button type="button" id="select-all-low-risk" class="button" data-all-low-risk-ids="<?php echo esc_attr(wp_json_encode($all_low_risk_ids)); ?>"><?php _e('Select All Low Risk', 'intersoccer-product-variations'); ?></button>
                             <button type="button" id="select-none" class="button"><?php _e('Deselect All', 'intersoccer-product-variations'); ?></button>
                             <button type="submit" name="update_selected_orders" class="button button-primary" id="update-selected-btn" disabled>
                                 <?php _e('Update Selected Orders', 'intersoccer-product-variations'); ?>
@@ -1359,11 +1414,18 @@ function intersoccer_render_update_orders_page() {
                     <?php if ($strip_deprecated_checked) : ?>
                         <input type="hidden" name="strip_deprecated_meta" value="1">
                     <?php endif; ?>
+                    <?php if ($prune_legacy_twins_checked) : ?>
+                        <input type="hidden" name="prune_legacy_twins" value="1">
+                    <?php else : ?>
+                        <input type="hidden" name="prune_legacy_twins" value="0">
+                    <?php endif; ?>
                     <?php wp_nonce_field('intersoccer_update_orders', 'intersoccer_update_orders_nonce'); ?>
                 </form>
             <?php endif; ?>
         <?php } ?>
+    <?php if (!$embedded) : ?>
     </div>
+    <?php endif; ?>
 
     <style>
         .intersoccer-summary-stats {
@@ -1409,21 +1471,32 @@ function intersoccer_render_update_orders_page() {
                 updateSummaryStats();
             });
             
-            // Select all low risk
+            // Select all low risk across the full scan result set (not only the current table page).
             $('#select-all-low-risk').on('click', function() {
+                var allLowIds = [];
+                try { allLowIds = JSON.parse($(this).attr('data-all-low-risk-ids') || '[]'); } catch (e) { allLowIds = []; }
+                allLowIds = allLowIds.map(function(id) { return String(id); });
                 $('input[name="order_ids[]"][data-risk="low"]').prop('checked', true);
-                updateSelection();
+                selectedOrders = allLowIds.length ? allLowIds.slice() : $('input[name="order_ids[]"][data-risk="low"]').map(function() {
+                    return $(this).val();
+                }).get();
+                $('#selected-order-ids').val(selectedOrders.join(','));
+                $('#update-selected-btn').prop('disabled', selectedOrders.length === 0);
+                $('#selected-count').text(selectedOrders.length);
                 updateSummaryStats();
             });
             
             // Deselect all
             $('#select-none').on('click', function() {
                 $('input[name="order_ids[]"]').prop('checked', false);
-                updateSelection();
+                selectedOrders = [];
+                $('#selected-order-ids').val('');
+                $('#update-selected-btn').prop('disabled', true);
+                $('#selected-count').text(0);
                 updateSummaryStats();
             });
             
-            // Update selected orders list
+            // Update selected orders list from visible checkboxes (page-local toggles).
             function updateSelection() {
                 selectedOrders = $('input[name="order_ids[]"]:checked').map(function() {
                     return $(this).val();
@@ -1478,7 +1551,7 @@ function intersoccer_render_update_orders_page() {
  * Enhanced JavaScript for real-time batch processing
  */
 function intersoccer_update_orders_scripts() {
-    if (isset($_GET['page']) && $_GET['page'] === 'intersoccer-update-orders') {
+    if (isset($_GET['page']) && in_array($_GET['page'], [intersoccer_order_meta_repair_page_slug(), 'intersoccer-update-orders'], true)) {
         ?>
         <script>
         jQuery(document).ready(function($) {
@@ -1492,7 +1565,15 @@ function intersoccer_update_orders_scripts() {
                         nonce: $('#intersoccer_update_orders_nonce').val(),
                         order_ids: orderIds,
                         start_index: startIndex,
-                        batch_size: batchSize
+                        batch_size: batchSize,
+                        fix_activity_type_only: $('input[name="fix_activity_type_only"]').filter(':checked').length ? '1' : ($('input[name="fix_activity_type_only"][type="hidden"]').val() || '0'),
+                        strip_deprecated_meta: $('input[name="strip_deprecated_meta"]').filter(':checked').length ? '1' : ($('input[name="strip_deprecated_meta"][type="hidden"]').val() || '0'),
+                        prune_legacy_twins: (function() {
+                            var $c = $('input[name="prune_legacy_twins"]').filter(':checked');
+                            if ($c.length) { return '1'; }
+                            var $h = $('input[name="prune_legacy_twins"][type="hidden"]');
+                            return $h.length ? String($h.val()) : '1';
+                        })()
                     }
                 });
             }
@@ -1501,9 +1582,15 @@ function intersoccer_update_orders_scripts() {
             $('#bulk-update-form').off('submit').on('submit', function(e) {
                 e.preventDefault();
                 
-                let selectedOrders = $('input[name="order_ids[]"]:checked').map(function() {
-                    return parseInt($(this).val());
-                }).get();
+                // Prefer the hidden full selection (covers Select All Low Risk across pages).
+                let selectedOrders = ($('#selected-order-ids').val() || '').split(',').filter(Boolean).map(function(v) {
+                    return parseInt(v, 10);
+                }).filter(function(id) { return id > 0; });
+                if (selectedOrders.length === 0) {
+                    selectedOrders = $('input[name="order_ids[]"]:checked').map(function() {
+                        return parseInt($(this).val(), 10);
+                    }).get();
+                }
                 
                 if (selectedOrders.length === 0) {
                     alert('<?php _e('Please select at least one order to update.', 'intersoccer-product-variations'); ?>');
@@ -1852,13 +1939,14 @@ function intersoccer_resolve_order_item_product_context($item) {
 
 /**
  * Detects and updates missing metadata from order item details
- * 
+ *
  * @param WC_Order $order The order to update
  * @param bool $fix_activity_type_only If true, only fixes incorrect Activity Type values
  * @param bool $strip_deprecated If true, remove deprecated meta keys from line items
+ * @param bool $prune_legacy_twins If true, remove wc_label / FR/DE twins when EN canonical exists; collapse same-key dups
  * @return bool True if any updates were made, false otherwise
  */
-function intersoccer_update_order_metadata($order, $fix_activity_type_only = false, $strip_deprecated = false) {
+function intersoccer_update_order_metadata($order, $fix_activity_type_only = false, $strip_deprecated = false, $prune_legacy_twins = false) {
     if (!($order instanceof WC_Order)) {
         if (defined('WP_DEBUG') && WP_DEBUG) {
             intersoccer_debug('InterSoccer: Skipped order ' . $order->get_id() . ' - Not a WC_Order (type: ' . get_class($order) . ')');
@@ -1891,6 +1979,12 @@ function intersoccer_update_order_metadata($order, $fix_activity_type_only = fal
             'fix_activity_type_only' => $fix_activity_type_only,
             'mode' => 'repair',
         ]);
+
+        if ($prune_legacy_twins && function_exists('intersoccer_prune_legacy_order_meta_twins')) {
+            if (intersoccer_prune_legacy_order_meta_twins($item)) {
+                $item_updated = true;
+            }
+        }
 
         if ($strip_deprecated) {
             $removed = intersoccer_strip_deprecated_order_line_meta($item);
@@ -2783,7 +2877,10 @@ function intersoccer_batch_update_orders_callback() {
         }
 
         try {
-            $success = intersoccer_update_order_metadata($order);
+            $fix_activity_type_only = isset($_POST['fix_activity_type_only']) && (string) $_POST['fix_activity_type_only'] === '1';
+            $strip_deprecated = isset($_POST['strip_deprecated_meta']) && (string) $_POST['strip_deprecated_meta'] === '1';
+            $prune_legacy_twins = !isset($_POST['prune_legacy_twins']) || (string) $_POST['prune_legacy_twins'] === '1';
+            $success = intersoccer_update_order_metadata($order, $fix_activity_type_only, $strip_deprecated, $prune_legacy_twins);
             
             // Count metadata after update
             foreach ($order->get_items() as $item) {
@@ -3003,7 +3100,9 @@ function intersoccer_automated_batch_update_callback() {
         }
         
         try {
-            $updated = intersoccer_update_order_metadata($order);
+            $strip_deprecated = !isset($_POST['strip_deprecated_meta']) || (string) $_POST['strip_deprecated_meta'] === '1';
+            $prune_legacy_twins = !isset($_POST['prune_legacy_twins']) || (string) $_POST['prune_legacy_twins'] === '1';
+            $updated = intersoccer_update_order_metadata($order, false, $strip_deprecated, $prune_legacy_twins);
             if ($updated) {
                 $results[] = ['order_id' => $order_id, 'status' => 'success', 'message' => 'Updated'];
                 $success_count++;
@@ -3105,14 +3204,19 @@ function intersoccer_get_orders_needing_updates($statuses, $limit = 1000) {
 }
 
 // Enhanced UI with automated processing controls
-function intersoccer_render_automated_update_orders_page() {
+function intersoccer_render_automated_update_orders_page($embedded = false) {
     if (!current_user_can('manage_woocommerce')) {
         wp_die(__('You do not have permission to access this page.', 'intersoccer-product-variations'));
     }
     ?>
+    <?php if (!$embedded) : ?>
     <div class="wrap">
         <h1><?php _e('Automated Order Metadata Update', 'intersoccer-product-variations'); ?></h1>
         <p><?php _e('Automatically find and update orders missing metadata. This tool can process hundreds or thousands of orders efficiently.', 'intersoccer-product-variations'); ?></p>
+    <?php else : ?>
+        <h2><?php esc_html_e('Automated batch', 'intersoccer-product-variations'); ?></h2>
+        <p><?php esc_html_e('Scan for orders needing updates, then process them in batches. Confirm before running with prune/strip enabled.', 'intersoccer-product-variations'); ?></p>
+    <?php endif; ?>
         
         <!-- Scan Configuration -->
         <div class="intersoccer-config-section" style="background: #fff; border: 1px solid #ccd0d4; padding: 20px; margin: 20px 0;">
@@ -3139,6 +3243,14 @@ function intersoccer_render_automated_update_orders_page() {
                             <option value="-1">All orders (may take very long)</option>
                         </select>
                         <p class="description"><?php _e('Higher numbers find more orders but take longer to scan initially.', 'intersoccer-product-variations'); ?></p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php _e('Repair Options', 'intersoccer-product-variations'); ?></th>
+                    <td>
+                        <label><input type="checkbox" id="batch-strip-deprecated" checked> <?php _e('Strip Deprecated Metadata', 'intersoccer-product-variations'); ?></label><br>
+                        <label><input type="checkbox" id="batch-prune-legacy-twins" checked> <?php _e('Prune legacy label twins', 'intersoccer-product-variations'); ?></label>
+                        <p class="description"><?php _e('Prune removes WC/FR/DE twin labels when English canonical keys exist. Confirm before mass runs.', 'intersoccer-product-variations'); ?></p>
                     </td>
                 </tr>
                 <tr>
@@ -3201,7 +3313,9 @@ function intersoccer_render_automated_update_orders_page() {
                 </button>
             </p>
         </div>
+    <?php if (!$embedded) : ?>
     </div>
+    <?php endif; ?>
     
     <script>
     jQuery(document).ready(function($) {
@@ -3230,11 +3344,18 @@ function intersoccer_render_automated_update_orders_page() {
             let scanLimit = parseInt($('#scan-limit').val());
             let batchSize = parseInt($('#batch-size').val());
             
-            if (!confirm(`This will scan up to ${scanLimit === -1 ? 'ALL' : scanLimit} orders and automatically update any missing metadata. This may take several minutes. Continue?`)) {
+            let stripDeprecated = $('#batch-strip-deprecated').is(':checked');
+            let pruneLegacyTwins = $('#batch-prune-legacy-twins').is(':checked');
+            let confirmMsg = `This will scan up to ${scanLimit === -1 ? 'ALL' : scanLimit} orders and automatically update missing metadata`;
+            if (stripDeprecated || pruneLegacyTwins) {
+                confirmMsg += ' with' + (stripDeprecated ? ' deprecated-key strip' : '') + (stripDeprecated && pruneLegacyTwins ? ' and' : '') + (pruneLegacyTwins ? ' legacy twin prune' : '');
+            }
+            confirmMsg += '. This may take several minutes. Continue?';
+            if (!confirm(confirmMsg)) {
                 return;
             }
             
-            startAutomatedProcessing(statuses, scanLimit, batchSize);
+            startAutomatedProcessing(statuses, scanLimit, batchSize, stripDeprecated, pruneLegacyTwins);
         });
         
         $('#stop-automated-update').on('click', function() {
@@ -3251,10 +3372,12 @@ function intersoccer_render_automated_update_orders_page() {
             resetCounters();
         });
         
-        function startAutomatedProcessing(statuses, scanLimit, batchSize) {
+        function startAutomatedProcessing(statuses, scanLimit, batchSize, stripDeprecated, pruneLegacyTwins) {
             processingActive = true;
             startTime = Date.now();
             resetCounters();
+            window.intersoccerBatchStripDeprecated = !!stripDeprecated;
+            window.intersoccerBatchPruneLegacyTwins = !!pruneLegacyTwins;
             
             $('#start-automated-update').hide();
             $('#stop-automated-update').show();
@@ -3280,7 +3403,9 @@ function intersoccer_render_automated_update_orders_page() {
                     batch_index: batchIndex,
                     batch_size: batchSize,
                     order_statuses: statuses,
-                    scan_limit: scanLimit
+                    scan_limit: scanLimit,
+                    strip_deprecated_meta: window.intersoccerBatchStripDeprecated ? '1' : '0',
+                    prune_legacy_twins: window.intersoccerBatchPruneLegacyTwins !== false ? '1' : '0'
                 },
                 timeout: 120000, // 2 minute timeout per batch
                 success: function(response) {
@@ -3471,7 +3596,7 @@ function intersoccer_cleanup_expired_batch_data() {
 }
 
 // Schedule cleanup if not already scheduled
-if (!wp_next_scheduled('intersoccer_cleanup_batch_data')) {
+if (function_exists('wp_next_scheduled') && function_exists('wp_schedule_event') && !wp_next_scheduled('intersoccer_cleanup_batch_data')) {
     wp_schedule_event(time(), 'daily', 'intersoccer_cleanup_batch_data');
 }
 

--- a/includes/woocommerce/order-meta-contract.php
+++ b/includes/woocommerce/order-meta-contract.php
@@ -669,6 +669,107 @@ function intersoccer_write_order_line_meta($item, array $context) {
 }
 
 /**
+ * Collapse multiple meta rows that share the same key into a single unique row.
+ * Keeps the last non-empty value (or last value if all empty).
+ *
+ * @param WC_Order_Item_Product $item
+ * @return bool Whether any change was made.
+ */
+function intersoccer_collapse_duplicate_order_meta_keys($item) {
+    if (!($item instanceof WC_Order_Item_Product)) {
+        return false;
+    }
+
+    $by_key = [];
+    foreach ($item->get_meta_data() as $meta) {
+        $key = (string) $meta->key;
+        if (!isset($by_key[$key])) {
+            $by_key[$key] = [];
+        }
+        $by_key[$key][] = $meta->value;
+    }
+
+    $changed = false;
+    foreach ($by_key as $key => $values) {
+        if (count($values) < 2) {
+            continue;
+        }
+        $kept = '';
+        foreach ($values as $value) {
+            if ($value !== null && $value !== '') {
+                $kept = $value;
+            }
+        }
+        if ($kept === '' && $values !== []) {
+            $kept = $values[count($values) - 1];
+        }
+        $item->delete_meta_data($key);
+        $item->add_meta_data($key, $kept, true);
+        $changed = true;
+    }
+
+    return $changed;
+}
+
+/**
+ * Aggressively remove legacy label twins when the EN canonical key is present.
+ *
+ * Unlike intersoccer_normalize_legacy_order_meta_keys(), this deletes reverse-map
+ * legacy keys even when the canonical key already has a value (A–C twins).
+ * Does not touch pa_* / attribute_pa_* / underscore camp twins (D).
+ *
+ * @param WC_Order_Item_Product $item
+ * @return bool Whether any change was made.
+ */
+function intersoccer_prune_legacy_order_meta_twins($item) {
+    if (!($item instanceof WC_Order_Item_Product)) {
+        return false;
+    }
+
+    if (!function_exists('intersoccer_attr_legacy_order_meta_label_reverse_map')) {
+        return false;
+    }
+
+    $reverse = intersoccer_attr_legacy_order_meta_label_reverse_map();
+    if (empty($reverse)) {
+        return false;
+    }
+
+    $existing = [];
+    foreach ($item->get_meta_data() as $meta) {
+        $existing[(string) $meta->key] = $meta->value;
+    }
+
+    $changed = intersoccer_normalize_legacy_order_meta_keys($item);
+
+    // Refresh after soft migrate.
+    $existing = [];
+    foreach ($item->get_meta_data() as $meta) {
+        $existing[(string) $meta->key] = $meta->value;
+    }
+
+    foreach ($existing as $raw_key => $value) {
+        if (!isset($reverse[$raw_key])) {
+            continue;
+        }
+        $canonical = (string) $reverse[$raw_key];
+        if ($canonical === $raw_key) {
+            continue;
+        }
+        if (!array_key_exists($canonical, $existing)) {
+            continue;
+        }
+        $item->delete_meta_data($raw_key);
+        unset($existing[$raw_key]);
+        $changed = true;
+    }
+
+    $changed = intersoccer_collapse_duplicate_order_meta_keys($item) || $changed;
+
+    return $changed;
+}
+
+/**
  * Strip deprecated keys from an order line item when assigned_player is present.
  *
  * @param WC_Order_Item_Product $item

--- a/includes/woocommerce/order-meta-repair-admin.php
+++ b/includes/woocommerce/order-meta-repair-admin.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Order Meta Repair admin helpers (slug + legacy redirects).
+ * Loaded from admin-ui.php; kept separate so PHPUnit can smoke-test without WP_List_Table.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Canonical admin page slug for the unified Order Meta Repair tool.
+ *
+ * @return string
+ */
+function intersoccer_order_meta_repair_page_slug() {
+    return 'intersoccer-order-meta-repair';
+}
+
+/**
+ * Redirect legacy Find Order Issues / Bulk Repair slugs to the unified page.
+ */
+function intersoccer_redirect_legacy_order_meta_repair_pages() {
+    if (!is_admin() || !isset($_GET['page'])) {
+        return;
+    }
+    $page = sanitize_key(wp_unslash((string) $_GET['page']));
+    $map = [
+        'intersoccer-update-orders' => 'scan',
+        'intersoccer-automated-updates' => 'batch',
+    ];
+    if (!isset($map[$page])) {
+        return;
+    }
+    if (!current_user_can('manage_woocommerce')) {
+        return;
+    }
+    $args = [
+        'page' => intersoccer_order_meta_repair_page_slug(),
+        'tab' => $map[$page],
+    ];
+    foreach (['order_statuses', 'preview_limit', 'fix_activity_type_only', 'strip_deprecated_meta', 'prune_legacy_twins', 'preview_updates', 'detailed_preview'] as $key) {
+        if (isset($_GET[$key])) {
+            $args[$key] = wp_unslash($_GET[$key]);
+        }
+    }
+    wp_safe_redirect(add_query_arg($args, admin_url('admin.php')));
+    // Allow PHPUnit to observe the redirect without terminating the process.
+    if (defined('INTERSOCCER_ORDER_META_REPAIR_TEST') && INTERSOCCER_ORDER_META_REPAIR_TEST) {
+        return;
+    }
+    exit;
+}

--- a/tests/OrderMetaContractTest.php
+++ b/tests/OrderMetaContractTest.php
@@ -383,4 +383,88 @@ class OrderMetaContractTest extends TestCase {
         $this->assertSame('Geneva', $item->get_meta('Sites InterSoccer', true));
     }
 
+    public function test_collapse_duplicate_same_key_rows() {
+        $item = new WC_Order_Item_Product([]);
+        $item->add_meta_data('Activity Type', 'Camp', false);
+        $item->add_meta_data('Activity Type', 'Course', false);
+
+        $changed = intersoccer_collapse_duplicate_order_meta_keys($item);
+
+        $this->assertTrue($changed);
+        $count = 0;
+        foreach ($item->get_meta_data() as $meta) {
+            if ($meta->key === 'Activity Type') {
+                $count++;
+            }
+        }
+        $this->assertSame(1, $count);
+        $this->assertSame('Course', $item->get_meta('Activity Type', true));
+    }
+
+    public function test_prune_removes_wc_venue_label_when_canonical_present() {
+        $item = new WC_Order_Item_Product([
+            'Sites InterSoccer' => 'Geneva',
+            'InterSoccer Venues' => 'Geneva',
+        ]);
+
+        $changed = intersoccer_prune_legacy_order_meta_twins($item);
+
+        $this->assertTrue($changed);
+        $this->assertSame('Geneva', $item->get_meta('Sites InterSoccer', true));
+        $this->assertSame('', $item->get_meta('InterSoccer Venues', true));
+    }
+
+    public function test_prune_removes_fr_de_legacy_when_en_canonical_present() {
+        $item = new WC_Order_Item_Product([
+            'Sites InterSoccer' => 'Geneva',
+            'Lieux InterSoccer' => 'Geneve',
+            'InterSoccer-Standorte' => 'Genf',
+        ]);
+
+        $changed = intersoccer_prune_legacy_order_meta_twins($item);
+
+        $this->assertTrue($changed);
+        $this->assertSame('Geneva', $item->get_meta('Sites InterSoccer', true));
+        $this->assertSame('', $item->get_meta('Lieux InterSoccer', true));
+        $this->assertSame('', $item->get_meta('InterSoccer-Standorte', true));
+    }
+
+    public function test_prune_retains_pa_slug_twin() {
+        $item = new WC_Order_Item_Product([
+            'Sites InterSoccer' => 'Geneva',
+            'pa_intersoccer-venues' => 'geneva',
+            'InterSoccer Venues' => 'Geneva',
+        ]);
+
+        intersoccer_prune_legacy_order_meta_twins($item);
+
+        $this->assertSame('Geneva', $item->get_meta('Sites InterSoccer', true));
+        $this->assertSame('geneva', $item->get_meta('pa_intersoccer-venues', true));
+        $this->assertSame('', $item->get_meta('InterSoccer Venues', true));
+    }
+
+    public function test_repair_write_collapses_preseeded_same_key_duplicate() {
+        $item = new WC_Order_Item_Product([]);
+        $item->add_meta_data('Activity Type', 'Camp', false);
+        $item->add_meta_data('Activity Type', 'Camp', false);
+
+        $written = intersoccer_write_order_line_meta($item, [
+            'mode' => 'repair',
+            'product_type' => 'camp',
+            'cart_values' => [],
+        ]);
+
+        // Soft normalize alone may not collapse; prune path is what repair UI uses.
+        intersoccer_prune_legacy_order_meta_twins($item);
+
+        $count = 0;
+        foreach ($item->get_meta_data() as $meta) {
+            if ($meta->key === 'Activity Type') {
+                $count++;
+            }
+        }
+        $this->assertSame(1, $count);
+        $this->assertTrue($written || $count === 1);
+    }
+
 }

--- a/tests/OrderMetaRepairMenuTest.php
+++ b/tests/OrderMetaRepairMenuTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Smoke tests for Order Meta Repair admin slug + legacy redirects.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if (!defined('INTERSOCCER_ORDER_META_REPAIR_TEST')) {
+    define('INTERSOCCER_ORDER_META_REPAIR_TEST', true);
+}
+
+if (!function_exists('is_admin')) {
+    function is_admin() {
+        return !empty($GLOBALS['intersoccer_test_is_admin']);
+    }
+}
+
+if (!function_exists('current_user_can')) {
+    function current_user_can($cap) {
+        return !empty($GLOBALS['intersoccer_test_can_manage']);
+    }
+}
+
+if (!function_exists('wp_unslash')) {
+    function wp_unslash($value) {
+        return $value;
+    }
+}
+
+if (!function_exists('add_query_arg')) {
+    function add_query_arg($key, $value = null, $url = null) {
+        if (is_array($key)) {
+            $args = $key;
+            $url = $value;
+        } else {
+            $args = [$key => $value];
+        }
+        $url = $url ?: '';
+        $sep = strpos($url, '?') === false ? '?' : '&';
+        return $url . $sep . http_build_query($args);
+    }
+}
+
+if (!function_exists('admin_url')) {
+    function admin_url($path = '') {
+        return 'https://example.test/wp-admin/' . ltrim((string) $path, '/');
+    }
+}
+
+if (!function_exists('wp_safe_redirect')) {
+    function wp_safe_redirect($location, $status = 302) {
+        $GLOBALS['intersoccer_test_redirect'] = $location;
+        return true;
+    }
+}
+
+require_once dirname(__DIR__) . '/includes/woocommerce/order-meta-repair-admin.php';
+
+class OrderMetaRepairMenuTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['intersoccer_test_redirect'] = null;
+        $GLOBALS['intersoccer_test_is_admin'] = true;
+        $GLOBALS['intersoccer_test_can_manage'] = true;
+        $_GET = [];
+    }
+
+    public function test_page_slug_is_unified_order_meta_repair() {
+        $this->assertSame('intersoccer-order-meta-repair', intersoccer_order_meta_repair_page_slug());
+    }
+
+    public function test_admin_ui_registers_unified_submenu_not_legacy_slugs() {
+        $src = file_get_contents(dirname(__DIR__) . '/includes/woocommerce/admin-ui.php');
+        $this->assertNotFalse($src);
+        $this->assertStringContainsString("intersoccer_order_meta_repair_page_slug()", $src);
+        $this->assertStringContainsString("intersoccer_render_order_meta_repair_page", $src);
+        // Old tools are not registered as submenu pages anymore.
+        $this->assertDoesNotMatchRegularExpression(
+            "/add_submenu_page\s*\([^;]*'intersoccer-update-orders'/s",
+            $src
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            "/add_submenu_page\s*\([^;]*'intersoccer-automated-updates'/s",
+            $src
+        );
+        $helper = file_get_contents(dirname(__DIR__) . '/includes/woocommerce/order-meta-repair-admin.php');
+        $this->assertStringContainsString("'intersoccer-update-orders'", $helper);
+        $this->assertStringContainsString("'intersoccer-automated-updates'", $helper);
+    }
+
+    public function test_legacy_scan_slug_redirects_to_unified_scan_tab() {
+        $_GET['page'] = 'intersoccer-update-orders';
+        intersoccer_redirect_legacy_order_meta_repair_pages();
+        $this->assertNotNull($GLOBALS['intersoccer_test_redirect']);
+        $this->assertStringContainsString('page=intersoccer-order-meta-repair', $GLOBALS['intersoccer_test_redirect']);
+        $this->assertStringContainsString('tab=scan', $GLOBALS['intersoccer_test_redirect']);
+    }
+
+    public function test_legacy_batch_slug_redirects_to_unified_batch_tab() {
+        $_GET['page'] = 'intersoccer-automated-updates';
+        intersoccer_redirect_legacy_order_meta_repair_pages();
+        $this->assertNotNull($GLOBALS['intersoccer_test_redirect']);
+        $this->assertStringContainsString('page=intersoccer-order-meta-repair', $GLOBALS['intersoccer_test_redirect']);
+        $this->assertStringContainsString('tab=batch', $GLOBALS['intersoccer_test_redirect']);
+    }
+}


### PR DESCRIPTION
Merge Find Order Issues and Bulk Repair into one WooCommerce tool with scan/batch tabs, aggressive legacy-label prune (A–C), cross-page Select All Low Risk, and contract/tests coverage.