### PR TITLE
Add Program Manager WPML sync for FR/DE camp schedule and variation w…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ This plugin enhances the WooCommerce booking system for InterSoccer Switzerland 
 
 Camp variations store `_camp_start_date`, `_camp_end_date`, and `_camp_week_index`. Program Manager can edit/pre-fill these and seed them from camp-terms via `wp intersoccer migrate-camp-dates`. Parsing dates from `pa_camp-terms` remains a **deprecated fallback** during migration — see `scratch/BACKLOG-remove-camp-terms-date-parse.md` and `.cursor/rules/camp-date-meta.mdc`.
 
+## Program Manager + WPML (EN source of truth)
+
+Edit the catalogue in the **default language (EN)**. Program Manager create/duplicate does **not** auto-create FR/DE product or variation translations — staff translate via WPML/WCML.
+
+When FR/DE variation siblings already exist, saving camp schedule, venue, course time, camp times, price, facet repair, or course meta from Program Manager (or camp schedule writers) copies those values onto the translated variations. New translations also receive camp schedule keys on `wpml_pro_translation_completed`. Empty schedule reads on a translation fall back to default-language meta via `intersoccer_get_camp_schedule()` (raw `intersoccer_get_camp_schedule_meta()` stays local-only for the PM editor).
+
 ## Features
 
 ### Product Types & Variations

--- a/includes/language-helpers.php
+++ b/includes/language-helpers.php
@@ -331,6 +331,123 @@ function intersoccer_get_discount_message_safe($rule_id, $message_type = 'cart_m
 }
 
 /**
+ * Variation IDs that are WPML translations of the given variation (excludes source).
+ *
+ * @param int $variation_id Source product_variation ID.
+ * @return int[]
+ */
+function intersoccer_foreach_translated_product_variations($variation_id) {
+    $variation_id = (int) $variation_id;
+    if ($variation_id <= 0) {
+        return [];
+    }
+    if (!defined('ICL_SITEPRESS_VERSION') && !function_exists('icl_get_current_language')) {
+        return [];
+    }
+
+    $languages = apply_filters('wpml_active_languages', null);
+    if (!$languages || !is_array($languages)) {
+        return [];
+    }
+
+    $original_lang = apply_filters('wpml_element_language_code', null, [
+        'element_id'   => $variation_id,
+        'element_type' => 'post_product_variation',
+    ]);
+    if (!$original_lang) {
+        $original_lang = apply_filters('wpml_current_language', null);
+    }
+
+    $ids = [];
+    foreach (array_keys($languages) as $lang_code) {
+        if ($lang_code === $original_lang) {
+            continue;
+        }
+        $tid = (int) apply_filters('wpml_object_id', $variation_id, 'product_variation', false, $lang_code);
+        if ($tid > 0 && $tid !== $variation_id) {
+            $ids[] = $tid;
+        }
+    }
+
+    return array_values(array_unique($ids));
+}
+
+/**
+ * Copy a taxonomy attribute slug to WPML-translated variations (meta + WC attrs when possible).
+ *
+ * @param int    $variation_id Source variation ID.
+ * @param string $taxonomy     e.g. pa_intersoccer-venues.
+ * @param string $slug         Attribute term slug (may be empty to clear).
+ * @return void
+ */
+function intersoccer_sync_variation_taxonomy_attribute_to_translations($variation_id, $taxonomy, $slug) {
+    $variation_id = (int) $variation_id;
+    $taxonomy     = sanitize_title((string) $taxonomy);
+    $slug         = sanitize_text_field((string) $slug);
+    if ($variation_id <= 0 || $taxonomy === '') {
+        return;
+    }
+
+    $meta_key = 'attribute_' . $taxonomy;
+    foreach (intersoccer_foreach_translated_product_variations($variation_id) as $tid) {
+        if (function_exists('wc_get_product')) {
+            $variation = wc_get_product($tid);
+            if ($variation && is_a($variation, 'WC_Product_Variation')) {
+                $attrs              = $variation->get_attributes();
+                $attrs[$taxonomy]   = $slug;
+                $variation->set_attributes($attrs);
+                $variation->save();
+            }
+        }
+        update_post_meta($tid, $meta_key, $slug);
+        if (function_exists('wp_set_object_terms')) {
+            if ($slug !== '') {
+                wp_set_object_terms($tid, $slug, $taxonomy);
+            } else {
+                wp_set_object_terms($tid, [], $taxonomy);
+            }
+        }
+        if (function_exists('wc_delete_product_transients')) {
+            wc_delete_product_transients($tid);
+        }
+    }
+}
+
+/**
+ * Copy regular/price to WPML-translated variations.
+ *
+ * @param int         $variation_id Source variation.
+ * @param string      $regular_price Regular price string.
+ * @param string|null $price         Active price (defaults to regular).
+ * @return void
+ */
+function intersoccer_sync_variation_prices_to_translations($variation_id, $regular_price, $price = null) {
+    $variation_id  = (int) $variation_id;
+    $regular_price = (string) $regular_price;
+    $price         = $price !== null ? (string) $price : $regular_price;
+    if ($variation_id <= 0 || !function_exists('wc_get_product')) {
+        return;
+    }
+
+    foreach (intersoccer_foreach_translated_product_variations($variation_id) as $tid) {
+        $variation = wc_get_product($tid);
+        if (!$variation || !is_a($variation, 'WC_Product_Variation')) {
+            continue;
+        }
+        $variation->set_regular_price($regular_price);
+        $variation->set_price($price);
+        $variation->save();
+        if (function_exists('wc_delete_product_transients')) {
+            $parent = (int) $variation->get_parent_id();
+            if ($parent > 0) {
+                wc_delete_product_transients($parent);
+            }
+            wc_delete_product_transients($tid);
+        }
+    }
+}
+
+/**
  * Initialize language functions and validate dependencies
  * Call this during plugin activation or admin_init
  */

--- a/includes/woocommerce/camp-schedule.php
+++ b/includes/woocommerce/camp-schedule.php
@@ -111,7 +111,148 @@ function intersoccer_update_camp_schedule($variation_id, $start = null, $end = n
 		}
 	}
 
+	if (function_exists('intersoccer_sync_camp_schedule_to_translations')) {
+		intersoccer_sync_camp_schedule_to_translations($variation_id);
+	}
+
 	return true;
+}
+
+/**
+ * Whether WPML (or compatible filter surface) is available for variation sync.
+ *
+ * @return bool
+ */
+function intersoccer_camp_schedule_wpml_available() {
+	return defined('ICL_SITEPRESS_VERSION') || function_exists('icl_get_current_language');
+}
+
+/**
+ * Copy camp schedule meta from a variation to its WPML translations (FR/DE, …).
+ * Uses update_post_meta only — does not call intersoccer_update_camp_schedule (no recursion).
+ *
+ * @param int $variation_id Source variation ID (any language).
+ * @return void
+ */
+function intersoccer_sync_camp_schedule_to_translations($variation_id) {
+	$variation_id = (int) $variation_id;
+	if ($variation_id <= 0 || !intersoccer_camp_schedule_wpml_available()) {
+		return;
+	}
+
+	$languages = apply_filters('wpml_active_languages', null);
+	if (!$languages || !is_array($languages)) {
+		return;
+	}
+
+	$keys     = intersoccer_camp_schedule_meta_keys();
+	$schedule = intersoccer_get_camp_schedule_meta($variation_id);
+
+	$siblings = function_exists('intersoccer_foreach_translated_product_variations')
+		? intersoccer_foreach_translated_product_variations($variation_id)
+		: [];
+
+	if ($siblings === []) {
+		// Fallback when language-helpers not loaded yet (same resolution as course sync).
+		$original_lang = apply_filters('wpml_element_language_code', null, [
+			'element_id'   => $variation_id,
+			'element_type' => 'post_product_variation',
+		]);
+		if (!$original_lang) {
+			$original_lang = apply_filters('wpml_current_language', null);
+		}
+		foreach (array_keys($languages) as $lang_code) {
+			if ($lang_code === $original_lang) {
+				continue;
+			}
+			$tid = (int) apply_filters('wpml_object_id', $variation_id, 'product_variation', false, $lang_code);
+			if ($tid > 0 && $tid !== $variation_id) {
+				$siblings[] = $tid;
+			}
+		}
+		$siblings = array_values(array_unique($siblings));
+	}
+
+	foreach ($siblings as $translated_variation_id) {
+		$translated_variation_id = (int) $translated_variation_id;
+		if ($translated_variation_id <= 0 || $translated_variation_id === $variation_id) {
+			continue;
+		}
+
+		if ($schedule['start'] === '') {
+			delete_post_meta($translated_variation_id, $keys['start']);
+		} else {
+			update_post_meta($translated_variation_id, $keys['start'], $schedule['start']);
+		}
+		if ($schedule['end'] === '') {
+			delete_post_meta($translated_variation_id, $keys['end']);
+		} else {
+			update_post_meta($translated_variation_id, $keys['end'], $schedule['end']);
+		}
+		if ($schedule['week'] === null || (int) $schedule['week'] <= 0) {
+			delete_post_meta($translated_variation_id, $keys['week']);
+		} else {
+			update_post_meta($translated_variation_id, $keys['week'], (int) $schedule['week']);
+		}
+
+		if (function_exists('wc_delete_product_transients')) {
+			wc_delete_product_transients($translated_variation_id);
+		}
+
+		if (defined('WP_DEBUG') && WP_DEBUG && function_exists('intersoccer_debug')) {
+			intersoccer_debug(
+				'Synced camp schedule from variation ' . $variation_id . ' to translated variation ' . $translated_variation_id
+			);
+		}
+	}
+}
+
+/**
+ * When a WPML translation of a camp variation is completed, copy schedule from default language.
+ *
+ * @param int                  $post_id Translated post ID.
+ * @param array<string,mixed>  $data    Job data.
+ * @param object|null          $job     Translation job.
+ * @return void
+ */
+function intersoccer_sync_camp_schedule_on_translation_complete($post_id, $data = [], $job = null) {
+	$post_id = (int) $post_id;
+	if ($post_id <= 0 || !intersoccer_camp_schedule_wpml_available()) {
+		return;
+	}
+	if (function_exists('get_post_type') && get_post_type($post_id) !== 'product_variation') {
+		return;
+	}
+
+	$parent_id = function_exists('wp_get_post_parent_id') ? (int) wp_get_post_parent_id($post_id) : 0;
+	if ($parent_id <= 0) {
+		return;
+	}
+	if (function_exists('intersoccer_is_camp') && !intersoccer_is_camp($parent_id)) {
+		return;
+	}
+
+	$original_lang = apply_filters('wpml_default_language', null) ?: 'en';
+	$original_variation_id = (int) apply_filters('wpml_object_id', $post_id, 'product_variation', true, $original_lang);
+	if ($original_variation_id <= 0 || $original_variation_id === $post_id) {
+		return;
+	}
+
+	$keys = intersoccer_camp_schedule_meta_keys();
+	foreach ($keys as $meta_key) {
+		$original_value = get_post_meta($original_variation_id, $meta_key, true);
+		if ($original_value !== '' && $original_value !== null) {
+			update_post_meta($post_id, $meta_key, $original_value);
+		}
+	}
+
+	if (function_exists('wc_delete_product_transients')) {
+		wc_delete_product_transients($post_id);
+	}
+}
+
+if (function_exists('add_action')) {
+	add_action('wpml_pro_translation_completed', 'intersoccer_sync_camp_schedule_on_translation_complete', 10, 3);
 }
 
 /**
@@ -214,6 +355,31 @@ function intersoccer_get_camp_schedule($variation_id, $allow_fallback = true) {
 
 	$needs_dates = ($out['start'] === '' || $out['end'] === '');
 	$needs_week  = ($out['week'] === null);
+
+	// WPML: empty translation meta → read default-language variation (before deprecated terms parse).
+	if ($allow_fallback && ($needs_dates || $needs_week) && intersoccer_camp_schedule_wpml_available()) {
+		$default_lang = apply_filters('wpml_default_language', null) ?: 'en';
+		$default_id   = (int) apply_filters('wpml_object_id', $variation_id, 'product_variation', true, $default_lang);
+		if ($default_id > 0 && $default_id !== $variation_id) {
+			$default_meta = intersoccer_get_camp_schedule_meta($default_id);
+			if ($out['start'] === '' && $default_meta['start'] !== '') {
+				$out['start']  = $default_meta['start'];
+				$out['source'] = 'wpml_default';
+			}
+			if ($out['end'] === '' && $default_meta['end'] !== '') {
+				$out['end']    = $default_meta['end'];
+				$out['source'] = 'wpml_default';
+			}
+			if ($out['week'] === null && $default_meta['week'] !== null) {
+				$out['week']   = $default_meta['week'];
+				if ($out['source'] === 'meta') {
+					$out['source'] = 'wpml_default';
+				}
+			}
+			$needs_dates = ($out['start'] === '' || $out['end'] === '');
+			$needs_week  = ($out['week'] === null);
+		}
+	}
 
 	if (!$allow_fallback || (!$needs_dates && !$needs_week)) {
 		return $out;

--- a/includes/woocommerce/program-manager.php
+++ b/includes/woocommerce/program-manager.php
@@ -1519,6 +1519,10 @@ class InterSoccer_Program_Manager {
 
 		wc_delete_product_transients($variation->get_parent_id());
 
+		if (function_exists('intersoccer_sync_variation_prices_to_translations')) {
+			intersoccer_sync_variation_prices_to_translations($variation_id, $price, $price);
+		}
+
 		wp_send_json_success(['variation_id' => $variation_id, 'price' => $price]);
 	}
 
@@ -1570,6 +1574,10 @@ class InterSoccer_Program_Manager {
 			wp_set_object_terms($variation_id, $venue_slug, 'pa_intersoccer-venues');
 		} else {
 			wp_set_object_terms($variation_id, [], 'pa_intersoccer-venues');
+		}
+
+		if (function_exists('intersoccer_sync_variation_taxonomy_attribute_to_translations')) {
+			intersoccer_sync_variation_taxonomy_attribute_to_translations($variation_id, 'pa_intersoccer-venues', $venue_slug);
 		}
 
 		wc_delete_product_transients($parent_id);
@@ -1626,6 +1634,10 @@ class InterSoccer_Program_Manager {
 			wp_set_object_terms($variation_id, $time_slug, 'pa_course-times');
 		} else {
 			wp_set_object_terms($variation_id, [], 'pa_course-times');
+		}
+
+		if (function_exists('intersoccer_sync_variation_taxonomy_attribute_to_translations')) {
+			intersoccer_sync_variation_taxonomy_attribute_to_translations($variation_id, 'pa_course-times', $time_slug);
 		}
 
 		wc_delete_product_transients($parent_id);
@@ -1806,6 +1818,9 @@ class InterSoccer_Program_Manager {
 			$attrs['pa_camp-times'] = $proposed;
 			$variation->set_attributes($attrs);
 			$variation->save();
+			if (function_exists('intersoccer_sync_variation_taxonomy_attribute_to_translations')) {
+				intersoccer_sync_variation_taxonomy_attribute_to_translations((int) $var_id, 'pa_camp-times', $proposed);
+			}
 			$updated++;
 			$rows[] = [
 				'variation_id' => $var_id,
@@ -2549,10 +2564,16 @@ class InterSoccer_Program_Manager {
 				if (!empty($attrs['pa_camp-terms'])) {
 					update_post_meta($var_id, 'attribute_pa_camp-terms', $attrs['pa_camp-terms']);
 					wp_set_object_terms($var_id, $attrs['pa_camp-terms'], 'pa_camp-terms');
+					if (function_exists('intersoccer_sync_variation_taxonomy_attribute_to_translations')) {
+						intersoccer_sync_variation_taxonomy_attribute_to_translations((int) $var_id, 'pa_camp-terms', (string) $attrs['pa_camp-terms']);
+					}
 				}
 				if (!empty($attrs['pa_intersoccer-venues'])) {
 					update_post_meta($var_id, 'attribute_pa_intersoccer-venues', $attrs['pa_intersoccer-venues']);
 					wp_set_object_terms($var_id, $attrs['pa_intersoccer-venues'], 'pa_intersoccer-venues');
+					if (function_exists('intersoccer_sync_variation_taxonomy_attribute_to_translations')) {
+						intersoccer_sync_variation_taxonomy_attribute_to_translations((int) $var_id, 'pa_intersoccer-venues', (string) $attrs['pa_intersoccer-venues']);
+					}
 				}
 				$persisted = wc_get_product($var_id);
 				$pa = $persisted ? $persisted->get_attributes() : [];
@@ -2622,6 +2643,21 @@ class InterSoccer_Program_Manager {
 					$value = (string) max(0, (int) $value);
 				}
 				update_post_meta($var_id, $meta_key, $value);
+			}
+			if (function_exists('intersoccer_sync_course_metadata_to_translations')) {
+				$start = (string) get_post_meta($var_id, '_course_start_date', true);
+				$weeks = (int) get_post_meta($var_id, '_course_total_weeks', true);
+				$holidays = get_post_meta($var_id, '_course_holiday_dates', true);
+				$discount = get_post_meta($var_id, '_course_weekly_discount', true);
+				$end = (string) get_post_meta($var_id, '_end_date', true);
+				intersoccer_sync_course_metadata_to_translations(
+					$var_id,
+					$start,
+					$weeks,
+					is_array($holidays) ? $holidays : [],
+					is_numeric($discount) ? (float) $discount : 0.0,
+					$end
+				);
 			}
 		}
 

--- a/tests/CampScheduleWpmlSyncTest.php
+++ b/tests/CampScheduleWpmlSyncTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * WPML sync for camp schedule meta (FR/DE siblings + default-lang read fallback).
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class CampScheduleWpmlSyncTest extends TestCase {
+	private int $en_id = 9101;
+	private int $fr_id = 9102;
+	private int $de_id = 9103;
+
+	protected function setUp(): void {
+		parent::setUp();
+		if (class_exists('MockMetaData')) {
+			MockMetaData::reset();
+		}
+		if (class_exists('MockFilters')) {
+			MockFilters::reset();
+		}
+
+		if (!defined('ICL_SITEPRESS_VERSION')) {
+			define('ICL_SITEPRESS_VERSION', '4.6-test');
+		}
+
+		require_once dirname(__DIR__) . '/includes/woocommerce/attribute-registry.php';
+		require_once dirname(__DIR__) . '/includes/language-helpers.php';
+		require_once dirname(__DIR__) . '/includes/woocommerce/camp-schedule.php';
+
+		$en = $this->en_id;
+		$fr = $this->fr_id;
+		$de = $this->de_id;
+
+		MockFilters::$filters['wpml_active_languages'] = static function () {
+			return [
+				'en' => ['code' => 'en'],
+				'fr' => ['code' => 'fr'],
+				'de' => ['code' => 'de'],
+			];
+		};
+		MockFilters::$filters['wpml_element_language_code'] = static function ($value, $args = null) use ($en) {
+			$id = is_array($args) ? (int) ($args['element_id'] ?? 0) : 0;
+			return $id === $en ? 'en' : $value;
+		};
+		MockFilters::$filters['wpml_current_language'] = static function () {
+			return 'en';
+		};
+		MockFilters::$filters['wpml_default_language'] = static function () {
+			return 'en';
+		};
+		MockFilters::$filters['wpml_object_id'] = static function ($id, $type = null, $return_original = null, $lang = null) use ($en, $fr, $de) {
+			$id = (int) $id;
+			if ($type !== 'product_variation') {
+				return $id;
+			}
+			$map = [
+				$en => ['en' => $en, 'fr' => $fr, 'de' => $de],
+				$fr => ['en' => $en, 'fr' => $fr, 'de' => $de],
+				$de => ['en' => $en, 'fr' => $fr, 'de' => $de],
+			];
+			if (!isset($map[$id])) {
+				return $id;
+			}
+			$lang = $lang ?: 'en';
+			return $map[$id][$lang] ?? $id;
+		};
+	}
+
+	public function test_update_camp_schedule_fans_out_to_fr_de_siblings(): void {
+		intersoccer_update_camp_schedule($this->en_id, '2026-07-06', '2026-07-10', 2, true);
+
+		$this->assertSame('2026-07-06', get_post_meta($this->fr_id, '_camp_start_date', true));
+		$this->assertSame('2026-07-10', get_post_meta($this->fr_id, '_camp_end_date', true));
+		$this->assertSame(2, (int) get_post_meta($this->fr_id, '_camp_week_index', true));
+
+		$this->assertSame('2026-07-06', get_post_meta($this->de_id, '_camp_start_date', true));
+		$this->assertSame('2026-07-10', get_post_meta($this->de_id, '_camp_end_date', true));
+		$this->assertSame(2, (int) get_post_meta($this->de_id, '_camp_week_index', true));
+	}
+
+	public function test_direct_sync_uses_post_meta_without_update_camp_schedule(): void {
+		update_post_meta($this->en_id, '_camp_start_date', '2026-08-03');
+		update_post_meta($this->en_id, '_camp_end_date', '2026-08-07');
+		update_post_meta($this->en_id, '_camp_week_index', 1);
+
+		// Fan-out must not call intersoccer_update_camp_schedule (would re-enter sync).
+		intersoccer_sync_camp_schedule_to_translations($this->en_id);
+
+		$this->assertSame('2026-08-03', get_post_meta($this->fr_id, '_camp_start_date', true));
+		$this->assertSame('2026-08-07', get_post_meta($this->de_id, '_camp_end_date', true));
+		// Source untouched by a recursive rewrite.
+		$this->assertSame('2026-08-03', get_post_meta($this->en_id, '_camp_start_date', true));
+	}
+
+	public function test_get_camp_schedule_falls_back_to_default_language_meta(): void {
+		update_post_meta($this->en_id, '_camp_start_date', '2026-09-07');
+		update_post_meta($this->en_id, '_camp_end_date', '2026-09-11');
+		update_post_meta($this->en_id, '_camp_week_index', 4);
+		// FR empty locally.
+		delete_post_meta($this->fr_id, '_camp_start_date');
+		delete_post_meta($this->fr_id, '_camp_end_date');
+		delete_post_meta($this->fr_id, '_camp_week_index');
+
+		$raw = intersoccer_get_camp_schedule_meta($this->fr_id);
+		$this->assertSame('', $raw['start']);
+
+		$schedule = intersoccer_get_camp_schedule($this->fr_id, true);
+		$this->assertSame('2026-09-07', $schedule['start']);
+		$this->assertSame('2026-09-11', $schedule['end']);
+		$this->assertSame(4, $schedule['week']);
+		$this->assertSame('wpml_default', $schedule['source']);
+	}
+
+	public function test_foreach_translated_product_variations_excludes_source(): void {
+		$siblings = intersoccer_foreach_translated_product_variations($this->en_id);
+		$this->assertEqualsCanonicalizing([$this->fr_id, $this->de_id], $siblings);
+		$this->assertNotContains($this->en_id, $siblings);
+	}
+
+	public function test_translation_complete_copies_schedule_from_default(): void {
+		update_post_meta($this->en_id, '_camp_start_date', '2026-10-05');
+		update_post_meta($this->en_id, '_camp_end_date', '2026-10-09');
+		update_post_meta($this->en_id, '_camp_week_index', 5);
+
+		if (!function_exists('intersoccer_is_camp')) {
+			function intersoccer_is_camp($product_id) {
+				return true;
+			}
+		}
+		if (!function_exists('get_post_type')) {
+			function get_post_type($post_id) {
+				return 'product_variation';
+			}
+		}
+		if (!function_exists('wp_get_post_parent_id')) {
+			function wp_get_post_parent_id($post_id) {
+				return 9999;
+			}
+		}
+
+		intersoccer_sync_camp_schedule_on_translation_complete($this->fr_id);
+
+		$this->assertSame('2026-10-05', get_post_meta($this->fr_id, '_camp_start_date', true));
+		$this->assertSame('2026-10-09', get_post_meta($this->fr_id, '_camp_end_date', true));
+		$this->assertSame(5, (int) get_post_meta($this->fr_id, '_camp_week_index', true));
+	}
+}

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -8,6 +8,11 @@
     <custom-field action="copy">_course_weekly_discount</custom-field>
     <custom-field action="copy">_end_date</custom-field>
 
+    <!-- Camp schedule (Program Manager / SoT dates) -->
+    <custom-field action="copy">_camp_start_date</custom-field>
+    <custom-field action="copy">_camp_end_date</custom-field>
+    <custom-field action="copy">_camp_week_index</custom-field>
+
     <!-- Camp/course display helpers -->
     <custom-field action="copy">_camp_times</custom-field>
 


### PR DESCRIPTION
…rites.

Mirror course meta sync for camp schedule keys, fan out PM venue/time/price/attrs to translated variations, document EN as source of truth, and cover sync with PHPUnit mocks.