### PR TITLE
Exclude birthday products from InterSoccer sibling discount baselines.

### DIFF
--- a/includes/woocommerce/admin-ui.php
+++ b/includes/woocommerce/admin-ui.php
@@ -379,7 +379,7 @@ function intersoccer_render_discounts_page() {
                             <?php _e('Count children from previous orders when applying sibling/multi-child discounts.', 'intersoccer-product-variations'); ?>
                         </label>
                         <p class="description">
-                            <?php _e('When enabled, camp and course sibling discounts use children booked in previous orders within the lookback period (not only children in the current cart). Tournament and birthday sibling discounts apply in the current cart only. Discounts apply only to the current cart.', 'intersoccer-product-variations'); ?>
+                            <?php _e('When enabled, camp and course sibling discounts use children booked in previous orders within the lookback period (not only children in the current cart). Tournament sibling discounts apply in the current cart only. Birthday products are not eligible for InterSoccer sibling or progressive discounts. Discounts apply only to the current cart.', 'intersoccer-product-variations'); ?>
                         </p>
                     </td>
                 </tr>

--- a/includes/woocommerce/discounts.php
+++ b/includes/woocommerce/discounts.php
@@ -429,6 +429,40 @@ function intersoccer_extract_course_items_from_order($order) {
 }
 
 /**
+ * Whether a product should be excluded from camp sibling prior-order baselines.
+ *
+ * Birthday products (typed or birthday-signal) never seed camp sibling/progressive ranking.
+ * Optional $product_type / $has_birthday_signals allow unit tests without WC bootstrap.
+ *
+ * @param int         $product_id
+ * @param string|null $product_type           Pre-resolved type or null to call intersoccer_get_product_type.
+ * @param bool|null   $has_birthday_signals   Pre-resolved signals or null to detect.
+ * @return bool True = skip (not a camp sibling baseline contributor).
+ */
+function intersoccer_discount_exclude_product_from_camp_sibling_baseline($product_id, $product_type = null, $has_birthday_signals = null) {
+    $product_id = (int) $product_id;
+    if ($product_id <= 0) {
+        return true;
+    }
+
+    if ($has_birthday_signals === null) {
+        $has_birthday_signals = function_exists('intersoccer_product_has_birthday_signals')
+            && intersoccer_product_has_birthday_signals($product_id);
+    }
+    if ($has_birthday_signals) {
+        return true;
+    }
+
+    if ($product_type === null) {
+        $product_type = function_exists('intersoccer_get_product_type')
+            ? intersoccer_get_product_type($product_id)
+            : null;
+    }
+
+    return $product_type === 'birthday' || $product_type !== 'camp';
+}
+
+/**
  * Extract camp items from an order
  * 
  * @param WC_Order $order Order object
@@ -441,9 +475,9 @@ function intersoccer_extract_camp_items_from_order($order) {
         $product_id = $item->get_product_id();
         $variation_id = $item->get_variation_id();
         
-        // Check if it's a camp
-        $product_type = intersoccer_get_product_type($variation_id ?: $product_id);
-        if ($product_type !== 'camp') {
+        // Camps only — never seed sibling baselines from birthday (incl. mis-typed camp meta).
+        $resolve_id = $variation_id ?: $product_id;
+        if (intersoccer_discount_exclude_product_from_camp_sibling_baseline($resolve_id)) {
             continue;
         }
         

--- a/includes/woocommerce/product-types.php
+++ b/includes/woocommerce/product-types.php
@@ -282,13 +282,14 @@ class InterSoccer_Product_Types {
     /**
      * True when the product is structured as a birthday package (not a camp/course).
      *
-     * Used to correct stale `_intersoccer_product_type` meta (e.g. camp) on birthday products.
+     * Used to correct stale `_intersoccer_product_type` meta (e.g. camp) on birthday products
+     * and to exclude birthday lines from camp sibling prior-order extract.
      *
      * @param int             $product_id
      * @param WC_Product|null $product
      * @return bool
      */
-    private static function product_has_birthday_signals($product_id, $product = null) {
+    public static function product_has_birthday_signals($product_id, $product = null) {
         $product_id = (int) $product_id;
         if ($product_id <= 0) {
             return false;
@@ -417,6 +418,20 @@ function intersoccer_is_course($product_id) {
  */
 function intersoccer_is_birthday($product_id) {
     return intersoccer_get_product_type($product_id) === 'birthday';
+}
+
+/**
+ * Birthday-signal detection without requiring resolved type meta (discount extract defense-in-depth).
+ *
+ * @param int             $product_id
+ * @param WC_Product|null $product
+ * @return bool
+ */
+function intersoccer_product_has_birthday_signals($product_id, $product = null) {
+    if (!class_exists('InterSoccer_Product_Types')) {
+        return false;
+    }
+    return InterSoccer_Product_Types::product_has_birthday_signals($product_id, $product);
 }
 
 /**

--- a/tests/BirthdayDiscountExclusionTest.php
+++ b/tests/BirthdayDiscountExclusionTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Birthday products must never seed camp sibling baselines or receive InterSoccer sibling discounts.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class BirthdayDiscountExclusionTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		if (!defined('ABSPATH')) {
+			define('ABSPATH', dirname(__DIR__) . '/');
+		}
+		if (!function_exists('__')) {
+			function __($text, $domain = null) {
+				return $text;
+			}
+		}
+		if (!function_exists('intersoccer_debug')) {
+			function intersoccer_debug($message) {
+			}
+		}
+		if (!function_exists('intersoccer_discount_exclude_product_from_camp_sibling_baseline')) {
+			require_once dirname(__DIR__) . '/includes/woocommerce/discounts.php';
+		}
+	}
+
+	public function test_typed_birthday_excluded_from_camp_sibling_baseline(): void {
+		$this->assertTrue(
+			intersoccer_discount_exclude_product_from_camp_sibling_baseline(1001, 'birthday', false)
+		);
+	}
+
+	public function test_camp_meta_with_birthday_signals_excluded(): void {
+		$this->assertTrue(
+			intersoccer_discount_exclude_product_from_camp_sibling_baseline(1002, 'camp', true),
+			'Mis-typed camp + birthday signals must not seed sibling totals'
+		);
+	}
+
+	public function test_real_camp_included_in_baseline(): void {
+		$this->assertFalse(
+			intersoccer_discount_exclude_product_from_camp_sibling_baseline(1003, 'camp', false)
+		);
+	}
+
+	public function test_course_and_tournament_excluded_from_camp_baseline(): void {
+		$this->assertTrue(intersoccer_discount_exclude_product_from_camp_sibling_baseline(1004, 'course', false));
+		$this->assertTrue(intersoccer_discount_exclude_product_from_camp_sibling_baseline(1005, 'tournament', false));
+	}
+
+	public function test_admin_copy_does_not_claim_birthday_sibling_discounts(): void {
+		$admin_ui = dirname(__DIR__) . '/includes/woocommerce/admin-ui.php';
+		$this->assertFileExists($admin_ui);
+		$contents = file_get_contents($admin_ui);
+		$this->assertStringNotContainsString(
+			'Tournament and birthday sibling discounts',
+			$contents,
+			'Settings copy must not claim birthday sibling discounts exist'
+		);
+		$this->assertStringContainsString(
+			'Birthday products are not eligible for InterSoccer sibling or progressive discounts',
+			$contents
+		);
+	}
+
+	public function test_helper_and_extract_guard_exist(): void {
+		$discounts = dirname(__DIR__) . '/includes/woocommerce/discounts.php';
+		$contents = file_get_contents($discounts);
+		$this->assertStringContainsString('function intersoccer_discount_exclude_product_from_camp_sibling_baseline', $contents);
+		$this->assertStringContainsString('intersoccer_discount_exclude_product_from_camp_sibling_baseline($resolve_id)', $contents);
+	}
+}


### PR DESCRIPTION
Harden camp prior-order extract against birthday-signal mis-typing, fix settings copy, and add PHPUnit coverage so birthday never seeds camp sibling discounts.