### PR TITLE
Add Program Manager Sync all languages (WPML).

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,19 @@ Camp variations store `_camp_start_date`, `_camp_end_date`, and `_camp_week_inde
 
 ## Program Manager + WPML (EN source of truth)
 
-Edit the catalogue in the **default language (EN)**. Program Manager create/duplicate does **not** auto-create FR/DE product or variation translations — staff translate via WPML/WCML.
+Edit the catalogue in the **default language (EN)**. Program Manager create/duplicate still creates EN products only.
 
-When FR/DE variation siblings already exist, saving camp schedule, venue, course time, camp times, price, facet repair, or course meta from Program Manager (or camp schedule writers) copies those values onto the translated variations. New translations also receive camp schedule keys on `wpml_pro_translation_completed`. Empty schedule reads on a translation fall back to default-language meta via `intersoccer_get_camp_schedule()` (raw `intersoccer_get_camp_schedule_meta()` stays local-only for the PM editor).
+Use **Sync all languages (WPML)** on the Program Manager detail page (or the list bulk action on any selected programs) to create or refresh FR/DE product and variation translations via WPML/WCML, then copy InterSoccer catalogue data onto those siblings. Sync copies **parent-level** taxonomy attributes (shared EN slugs, including non-variation fields like `pa_program-year` / `pa_girls-only`) and **variation** schedule, attrs, prices, and course meta. Newly created/refreshed parents also receive the EN product status (draft/publish/private). Do not hand-edit English attributes onto FR/DE products — run Sync instead.
+
+When FR/DE variation siblings already exist, saving camp schedule, venue, course time, camp times, price, facet repair, or course meta from Program Manager (or camp schedule writers) also copies those values onto the translated variations. New translations receive camp schedule keys on `wpml_pro_translation_completed`. Empty schedule reads on a translation fall back to default-language meta via `intersoccer_get_camp_schedule()` (raw `intersoccer_get_camp_schedule_meta()` stays local-only for the PM editor).
 
 ## Catalogue year-roll (Bulk Duplicate)
 
 - Seasons stay **evergreen** (`pa_program-season`: Autumn/Winter/Spring/Summer). Year lives on **`pa_program-year`** and in product titles — do **not** create `Autumn 2027`-style season terms.
-- Select rows → Bulk Actions **Duplicate to year…** → year/season fields appear beside the dropdown → Apply. Creates **Draft** clones (checked rows only) with year/season/title updates. Prices and camp/course dates are **not** copied — edit those, then WPML Sync, then Publish.
+- Select rows → Bulk Actions **Duplicate to year…** → year/season fields appear beside the dropdown → Apply. Creates **Draft** clones (checked rows only) with year/season/title updates. Prices and camp/course dates are **not** copied — edit those, then **Sync all languages (WPML)**, then Publish.
 - Lifecycle: **Publish** = live; **Private** = retired sold years (orders still resolve); **Draft** = WIP. No auto-close of products/variations; roster close remains Reports/Rosters-only.
 - Same-season course discounts and sibling season filters key on **`season|pa_program-year`** so evergreen Autumn does not cross-discount across years.
-- Program Manager status quick-edit fans out **draft / publish / private** to FR/DE product translations when they exist.
+- Program Manager status quick-edit fans out **draft / publish / private** to FR/DE product translations when they exist; Sync also applies EN status after create/refresh.
 - Ops note: Obsidian `Fixing Products — Program Manager`.
 
 ## Features

--- a/includes/woocommerce/pm-wpml-sync.php
+++ b/includes/woocommerce/pm-wpml-sync.php
@@ -1,0 +1,553 @@
+<?php
+/**
+ * Program Manager — Sync all languages (WPML/WCML).
+ *
+ * Creates/links missing FR/DE product + variation translations via WPML/WCML APIs,
+ * then fans out InterSoccer catalogue data using shared EN attribute slugs.
+ * Also copies parent-level taxonomy attributes (e.g. pa_program-year, pa_girls-only)
+ * so legacy translations incomplete before Program Manager become catalogue-complete.
+ *
+ * @package InterSoccer_Product_Variations
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Taxonomy attributes copied to translations as shared EN slugs.
+ *
+ * @return string[]
+ */
+function intersoccer_pm_wpml_sync_attribute_taxonomies() {
+	return [
+		'pa_activity-type',
+		'pa_intersoccer-venues',
+		'pa_program-season',
+		'pa_age-group',
+		'pa_canton-region',
+		'pa_city',
+		'pa_booking-type',
+		'pa_days-of-week',
+		'pa_camp-terms',
+		'pa_course-day',
+		'pa_course-times',
+		'pa_camp-times',
+		'pa_girls-only',
+		'pa_date',
+		'pa_tournament-day',
+		'pa_tournament-time',
+		'pa_note',
+	];
+}
+
+/**
+ * Whether WPML is available for product translation sync.
+ *
+ * @return bool
+ */
+function intersoccer_pm_wpml_available() {
+	return defined('ICL_SITEPRESS_VERSION') || function_exists('icl_get_current_language');
+}
+
+/**
+ * Resolve a WC product (filterable for unit tests).
+ *
+ * @param int $product_id
+ * @return mixed WC_Product|false
+ */
+function intersoccer_pm_wpml_get_product($product_id) {
+	$product_id = (int) $product_id;
+	$filtered = apply_filters('intersoccer_pm_wpml_get_product', null, $product_id);
+	if ($filtered !== null) {
+		return $filtered;
+	}
+	if (!function_exists('wc_get_product')) {
+		return false;
+	}
+	return wc_get_product($product_id);
+}
+
+/**
+ * Empty sync report.
+ *
+ * @param int $product_id
+ * @return array
+ */
+function intersoccer_pm_wpml_sync_empty_report($product_id = 0) {
+	return [
+		'ok'                   => false,
+		'source_product_id'    => (int) $product_id,
+		'parents_created'      => [],
+		'parents_synced'       => [],
+		'parents_attrs_updated'=> 0,
+		'status_synced'        => [],
+		'variations_linked'    => 0,
+		'meta_synced'          => 0,
+		'skipped'              => [],
+		'errors'               => [],
+		'message'              => '',
+	];
+}
+
+/**
+ * Resolve the default-language product ID to sync from.
+ *
+ * @param int $product_id Requested product ID (any language).
+ * @return array{id:int,default_lang:string,error:?string}
+ */
+function intersoccer_pm_wpml_resolve_source_product($product_id) {
+	$product_id = (int) $product_id;
+	$default_lang = apply_filters('wpml_default_language', null) ?: 'en';
+
+	if ($product_id <= 0) {
+		return ['id' => 0, 'default_lang' => $default_lang, 'error' => 'invalid_product'];
+	}
+
+	$source_id = (int) apply_filters('wpml_object_id', $product_id, 'product', true, $default_lang);
+	if ($source_id <= 0) {
+		$source_id = $product_id;
+	}
+
+	$lang = apply_filters('wpml_element_language_code', null, [
+		'element_id'   => $source_id,
+		'element_type' => 'post_product',
+	]);
+	if ($lang && $lang !== $default_lang) {
+		$resolved = (int) apply_filters('wpml_object_id', $source_id, 'product', true, $default_lang);
+		if ($resolved > 0) {
+			$source_id = $resolved;
+		}
+	}
+
+	return ['id' => $source_id, 'default_lang' => $default_lang, 'error' => null];
+}
+
+/**
+ * Create a product translation via WPML (filterable for tests).
+ *
+ * @param int    $master_id Default-language product ID.
+ * @param string $lang      Target language code.
+ * @return int|false New product ID or false.
+ */
+function intersoccer_pm_wpml_make_duplicate($master_id, $lang) {
+	$master_id = (int) $master_id;
+	$lang      = sanitize_key((string) $lang);
+	if ($master_id <= 0 || $lang === '') {
+		return false;
+	}
+
+	$filtered = apply_filters('intersoccer_pm_wpml_make_duplicate', null, $master_id, $lang);
+	if ($filtered !== null) {
+		return is_numeric($filtered) ? (int) $filtered : false;
+	}
+
+	global $sitepress;
+	if (!$sitepress || !is_object($sitepress) || !method_exists($sitepress, 'make_duplicate')) {
+		return false;
+	}
+
+	$result = $sitepress->make_duplicate($master_id, $lang);
+	if (is_wp_error($result) || !$result) {
+		return false;
+	}
+
+	return (int) $result;
+}
+
+/**
+ * Ask WCML to synchronize product components (variations, attributes, …).
+ *
+ * @param WP_Post|object $product_post EN product post.
+ * @param int[]          $tr_ids       Translation product IDs.
+ * @param array          $lang_map     Map translation_id => language code.
+ * @return void
+ */
+function intersoccer_pm_wcml_synchronize_product($product_post, array $tr_ids, array $lang_map) {
+	$handled = apply_filters('intersoccer_pm_wcml_synchronize_product', false, $product_post, $tr_ids, $lang_map);
+	if ($handled) {
+		return;
+	}
+
+	if (!function_exists('has_action') || has_action('wcml_synchronize_product_translations')) {
+		if (function_exists('do_action')) {
+			do_action('wcml_synchronize_product_translations', $product_post, $tr_ids, $lang_map);
+		}
+		return;
+	}
+
+	global $woocommerce_wpml;
+	if ($woocommerce_wpml && isset($woocommerce_wpml->sync_variations_data)
+		&& is_object($woocommerce_wpml->sync_variations_data)
+		&& method_exists($woocommerce_wpml->sync_variations_data, 'sync_product_variations')) {
+		foreach ($lang_map as $tr_id => $lang) {
+			$woocommerce_wpml->sync_variations_data->sync_product_variations(
+				(int) $product_post->ID,
+				(int) $tr_id,
+				$lang,
+				['is_duplicate' => true]
+			);
+		}
+	}
+}
+
+/**
+ * Copy parent taxonomy attribute options (shared EN slugs) onto translated parents.
+ * Fixes legacy FR/DE products missing non-variation attrs like pa_program-year / pa_girls-only.
+ *
+ * @param int   $source_id Default-language product ID.
+ * @param int[] $tr_ids    Translation product IDs.
+ * @return int Number of translation parents updated.
+ */
+function intersoccer_pm_wpml_sync_parent_attributes($source_id, array $tr_ids) {
+	$source_id = (int) $source_id;
+	$source    = intersoccer_pm_wpml_get_product($source_id);
+	if (!$source || !is_object($source) || !method_exists($source, 'get_attributes')) {
+		return 0;
+	}
+	if (!class_exists('WC_Product_Attribute')) {
+		return 0;
+	}
+
+	$source_attrs = $source->get_attributes();
+	if (!is_array($source_attrs) || $source_attrs === []) {
+		return 0;
+	}
+
+	$updated = 0;
+	foreach ($tr_ids as $tr_id) {
+		$tr_id = (int) $tr_id;
+		if ($tr_id <= 0 || $tr_id === $source_id) {
+			continue;
+		}
+		$tr = intersoccer_pm_wpml_get_product($tr_id);
+		if (!$tr || !is_object($tr) || !method_exists($tr, 'get_attributes')) {
+			continue;
+		}
+
+		$new_attrs = $tr->get_attributes();
+		if (!is_array($new_attrs)) {
+			$new_attrs = [];
+		}
+		$changed = false;
+
+		foreach ($source_attrs as $taxonomy => $attr) {
+			$taxonomy = (string) $taxonomy;
+			if ($taxonomy === '' || !is_object($attr)) {
+				continue;
+			}
+			if (strpos($taxonomy, 'pa_') !== 0 || !taxonomy_exists($taxonomy)) {
+				continue;
+			}
+
+			$slugs = [];
+			if (function_exists('wc_get_product_terms')) {
+				$slugs = wc_get_product_terms($source_id, $taxonomy, ['fields' => 'slugs']);
+				if (is_wp_error($slugs)) {
+					$slugs = [];
+				}
+			}
+			if ($slugs === [] && method_exists($attr, 'get_options')) {
+				foreach ((array) $attr->get_options() as $opt) {
+					if (is_numeric($opt)) {
+						$term = get_term((int) $opt, $taxonomy);
+						if ($term && !is_wp_error($term)) {
+							$slugs[] = $term->slug;
+						}
+					} elseif (is_string($opt) && $opt !== '') {
+						$slugs[] = $opt;
+					}
+				}
+			}
+			$slugs = array_values(array_unique(array_filter(array_map('strval', $slugs))));
+			if ($slugs === []) {
+				continue;
+			}
+
+			if (function_exists('wp_set_object_terms')) {
+				wp_set_object_terms($tr_id, $slugs, $taxonomy);
+			}
+
+			$term_ids = [];
+			foreach ($slugs as $slug) {
+				$term = get_term_by('slug', $slug, $taxonomy);
+				if ($term && !is_wp_error($term)) {
+					$term_ids[] = (int) $term->term_id;
+				}
+			}
+			if ($term_ids === []) {
+				continue;
+			}
+
+			$is_variation = method_exists($attr, 'get_variation') ? (bool) $attr->get_variation() : false;
+			$is_visible   = method_exists($attr, 'get_visible') ? (bool) $attr->get_visible() : true;
+			$attr_id      = function_exists('wc_attribute_taxonomy_id_by_name')
+				? (int) wc_attribute_taxonomy_id_by_name($taxonomy)
+				: 0;
+
+			if (isset($new_attrs[$taxonomy]) && is_object($new_attrs[$taxonomy])) {
+				$new_attrs[$taxonomy]->set_id($attr_id);
+				$new_attrs[$taxonomy]->set_name($taxonomy);
+				$new_attrs[$taxonomy]->set_options($term_ids);
+				$new_attrs[$taxonomy]->set_variation($is_variation);
+				$new_attrs[$taxonomy]->set_visible($is_visible);
+			} else {
+				$attribute = new WC_Product_Attribute();
+				$attribute->set_id($attr_id);
+				$attribute->set_name($taxonomy);
+				$attribute->set_options($term_ids);
+				$attribute->set_visible($is_visible);
+				$attribute->set_variation($is_variation);
+				$new_attrs[$taxonomy] = $attribute;
+			}
+			$changed = true;
+		}
+
+		if ($changed) {
+			$tr->set_attributes($new_attrs);
+			$tr->save();
+			if (function_exists('wc_delete_product_transients')) {
+				wc_delete_product_transients($tr_id);
+			}
+			$updated++;
+		}
+	}
+
+	return $updated;
+}
+
+/**
+ * Fan out InterSoccer variation data from an EN variation to WPML siblings.
+ *
+ * @param int $variation_id EN (source) variation ID.
+ * @return int Number of sibling variations touched (attrs/price/schedule/meta).
+ */
+function intersoccer_pm_wpml_fan_out_variation($variation_id) {
+	$variation_id = (int) $variation_id;
+	if ($variation_id <= 0) {
+		return 0;
+	}
+
+	$siblings = function_exists('intersoccer_foreach_translated_product_variations')
+		? intersoccer_foreach_translated_product_variations($variation_id)
+		: [];
+	if ($siblings === []) {
+		return 0;
+	}
+
+	$touched = count($siblings);
+
+	if (function_exists('intersoccer_sync_camp_schedule_to_translations')) {
+		intersoccer_sync_camp_schedule_to_translations($variation_id);
+	}
+
+	$attrs = [];
+	if (function_exists('wc_get_product')) {
+		$variation = wc_get_product($variation_id);
+		if ($variation && is_a($variation, 'WC_Product_Variation')) {
+			$attrs = $variation->get_attributes();
+			$regular = $variation->get_regular_price();
+			$price   = $variation->get_price();
+			if ($regular !== '' && $regular !== null && function_exists('intersoccer_sync_variation_prices_to_translations')) {
+				intersoccer_sync_variation_prices_to_translations($variation_id, (string) $regular, (string) $price);
+			}
+		}
+	}
+
+	foreach (intersoccer_pm_wpml_sync_attribute_taxonomies() as $taxonomy) {
+		$slug = '';
+		if (isset($attrs[$taxonomy]) && $attrs[$taxonomy] !== '') {
+			$slug = (string) $attrs[$taxonomy];
+		} else {
+			$meta = get_post_meta($variation_id, 'attribute_' . $taxonomy, true);
+			if (is_string($meta) && $meta !== '') {
+				$slug = $meta;
+			}
+		}
+		if ($slug === '' && empty($attrs[$taxonomy])) {
+			continue;
+		}
+		if (function_exists('intersoccer_sync_variation_taxonomy_attribute_to_translations')) {
+			intersoccer_sync_variation_taxonomy_attribute_to_translations($variation_id, $taxonomy, $slug);
+		}
+	}
+
+	if (function_exists('intersoccer_sync_course_metadata_to_translations')) {
+		$start = (string) get_post_meta($variation_id, '_course_start_date', true);
+		if ($start !== '') {
+			$weeks    = (int) get_post_meta($variation_id, '_course_total_weeks', true);
+			$holidays = get_post_meta($variation_id, '_course_holiday_dates', true);
+			$discount = get_post_meta($variation_id, '_course_weekly_discount', true);
+			$end      = (string) get_post_meta($variation_id, '_end_date', true);
+			intersoccer_sync_course_metadata_to_translations(
+				$variation_id,
+				$start,
+				$weeks,
+				is_array($holidays) ? $holidays : [],
+				is_numeric($discount) ? (float) $discount : 0.0,
+				$end
+			);
+		}
+	}
+
+	foreach ([
+		'_intersoccer_enable_late_pickup',
+		'_intersoccer_camp_days_available',
+		'_intersoccer_late_pickup_days_available',
+		'_intersoccer_product_type',
+		'_camp_times',
+	] as $meta_key) {
+		$value = get_post_meta($variation_id, $meta_key, true);
+		if ($value === '' || $value === null || $value === false) {
+			continue;
+		}
+		foreach ($siblings as $tid) {
+			update_post_meta((int) $tid, $meta_key, $value);
+		}
+	}
+
+	return $touched;
+}
+
+/**
+ * Sync all active languages for a variable product (EN source of truth).
+ *
+ * Applies to any Program Manager program (camp, course, birthday, tournament):
+ * create/link FR/DE parents + variations, copy parent attrs, fan out variation data.
+ *
+ * @param int $product_id Product ID (resolved to default language).
+ * @return array Report (see intersoccer_pm_wpml_sync_empty_report).
+ */
+function intersoccer_pm_sync_product_translations($product_id) {
+	$report = intersoccer_pm_wpml_sync_empty_report($product_id);
+
+	if (!intersoccer_pm_wpml_available()) {
+		$report['errors'][] = 'wpml_unavailable';
+		$report['message']  = __('WPML is not available.', 'intersoccer-product-variations');
+		return $report;
+	}
+
+	$resolved = intersoccer_pm_wpml_resolve_source_product($product_id);
+	$source_id = (int) $resolved['id'];
+	$default_lang = (string) $resolved['default_lang'];
+	$report['source_product_id'] = $source_id;
+
+	if ($source_id <= 0) {
+		$report['errors'][] = 'invalid_product';
+		$report['message']  = __('Invalid product.', 'intersoccer-product-variations');
+		return $report;
+	}
+
+	$product = intersoccer_pm_wpml_get_product($source_id);
+	if (!$product || !is_object($product) || !method_exists($product, 'is_type') || !$product->is_type('variable')) {
+		$report['errors'][] = 'not_variable';
+		$report['message']  = __('Product must be a variable product.', 'intersoccer-product-variations');
+		return $report;
+	}
+
+	$languages = apply_filters('wpml_active_languages', null);
+	if (!$languages || !is_array($languages)) {
+		$report['errors'][] = 'no_languages';
+		$report['message']  = __('No active WPML languages found.', 'intersoccer-product-variations');
+		return $report;
+	}
+
+	$product_post = function_exists('get_post') ? get_post($source_id) : null;
+	if (!$product_post) {
+		$product_post = (object) ['ID' => $source_id, 'post_type' => 'product'];
+	}
+
+	$tr_ids_for_sync = [];
+	$lang_map        = [];
+
+	foreach (array_keys($languages) as $lang_code) {
+		$lang_code = sanitize_key((string) $lang_code);
+		if ($lang_code === '' || $lang_code === $default_lang) {
+			continue;
+		}
+
+		$existing = (int) apply_filters('wpml_object_id', $source_id, 'product', false, $lang_code);
+		if ($existing > 0 && $existing !== $source_id) {
+			$report['parents_synced'][$lang_code] = $existing;
+			$tr_ids_for_sync[] = $existing;
+			$lang_map[$existing] = $lang_code;
+			continue;
+		}
+
+		$created = intersoccer_pm_wpml_make_duplicate($source_id, $lang_code);
+		if ($created > 0 && $created !== $source_id) {
+			$report['parents_created'][$lang_code] = $created;
+			$tr_ids_for_sync[] = $created;
+			$lang_map[$created] = $lang_code;
+		} else {
+			$report['errors'][] = 'create_failed_' . $lang_code;
+			$report['skipped'][] = $lang_code;
+		}
+	}
+
+	if ($tr_ids_for_sync !== []) {
+		intersoccer_pm_wcml_synchronize_product($product_post, $tr_ids_for_sync, $lang_map);
+		$report['parents_attrs_updated'] = intersoccer_pm_wpml_sync_parent_attributes($source_id, $tr_ids_for_sync);
+	}
+
+	$children = $product->get_children();
+	$meta_synced = 0;
+	$variations_linked = 0;
+
+	foreach ($children as $var_id) {
+		$var_id = (int) $var_id;
+		$before = function_exists('intersoccer_foreach_translated_product_variations')
+			? intersoccer_foreach_translated_product_variations($var_id)
+			: [];
+		$touched = intersoccer_pm_wpml_fan_out_variation($var_id);
+		$after = function_exists('intersoccer_foreach_translated_product_variations')
+			? intersoccer_foreach_translated_product_variations($var_id)
+			: [];
+		$new_links = count(array_diff($after, $before));
+		$variations_linked += max($new_links, 0);
+		if ($touched > 0) {
+			$meta_synced += $touched;
+		}
+	}
+
+	if ($variations_linked === 0 && $tr_ids_for_sync !== []) {
+		foreach ($children as $var_id) {
+			$siblings = function_exists('intersoccer_foreach_translated_product_variations')
+				? intersoccer_foreach_translated_product_variations((int) $var_id)
+				: [];
+			$variations_linked += count($siblings);
+		}
+	}
+
+	$report['variations_linked'] = $variations_linked;
+	$report['meta_synced']       = $meta_synced;
+
+	// Match EN product status onto FR/DE parents (create + refresh).
+	$en_status = method_exists($product, 'get_status') ? (string) $product->get_status() : '';
+	if ($en_status !== '' && function_exists('intersoccer_sync_product_status_to_translations')) {
+		$report['status_synced'] = intersoccer_sync_product_status_to_translations($source_id, $en_status);
+	} else {
+		$report['status_synced'] = [];
+	}
+
+	$report['ok'] = empty($report['errors']);
+
+	$created_n = count($report['parents_created']);
+	$synced_n  = count($report['parents_synced']);
+	$report['message'] = sprintf(
+		/* translators: 1: parents created, 2: parents refreshed, 3: variation siblings synced */
+		__('WPML sync: %1$d language(s) created, %2$d refreshed, %3$d variation sibling(s) updated.', 'intersoccer-product-variations'),
+		$created_n,
+		$synced_n,
+		$meta_synced
+	);
+
+	if (function_exists('wc_delete_product_transients')) {
+		wc_delete_product_transients($source_id);
+		foreach ($lang_map as $tr_id => $_lang) {
+			wc_delete_product_transients((int) $tr_id);
+		}
+	}
+
+	return $report;
+}

--- a/includes/woocommerce/program-manager.php
+++ b/includes/woocommerce/program-manager.php
@@ -41,6 +41,7 @@ class InterSoccer_Program_Manager {
 		add_action('wp_ajax_intersoccer_pm_apply_parsed_camp_dates', [__CLASS__, 'ajax_apply_parsed_camp_dates']);
 		add_action('wp_ajax_intersoccer_pm_propose_camp_times', [__CLASS__, 'ajax_propose_camp_times']);
 		add_action('wp_ajax_intersoccer_pm_repair_camp_facets', [__CLASS__, 'ajax_repair_camp_facets']);
+		add_action('wp_ajax_intersoccer_pm_sync_wpml_languages', [__CLASS__, 'ajax_sync_wpml_languages']);
 		add_action('wp_ajax_intersoccer_pm_quick_edit', [__CLASS__, 'ajax_quick_edit']);
 		add_action('wp_ajax_intersoccer_pm_duplicate_program', [__CLASS__, 'ajax_duplicate_program']);
 		add_action('wp_ajax_intersoccer_pm_save_parent_attrs', [__CLASS__, 'ajax_save_parent_attrs']);
@@ -70,7 +71,7 @@ class InterSoccer_Program_Manager {
 			'intersoccer-program-manager',
 			INTERSOCCER_PRODUCT_VARIATIONS_PLUGIN_URL . 'js/program-manager.js',
 			['jquery'],
-			'2.7.31.1',
+			'2.7.31.2',
 			true
 		);
 
@@ -84,11 +85,13 @@ class InterSoccer_Program_Manager {
 				'confirm_create'    => __('Create this program as a Draft product?', 'intersoccer-product-variations'),
 				'confirm_duplicate' => __('Duplicate this program? A new Draft product will be created.', 'intersoccer-product-variations'),
 				'confirm_refresh'   => __('Refresh attributes on all unhealthy variations? This applies default values for missing fields.', 'intersoccer-product-variations'),
+				'confirm_sync_wpml' => __('Sync all languages (WPML)? This creates or refreshes FR/DE product and variation translations from English, copying shared attribute slugs, schedule, prices, and course meta.', 'intersoccer-product-variations'),
 				'saving'            => __('Saving…', 'intersoccer-product-variations'),
 				'saved'             => __('Saved', 'intersoccer-product-variations'),
 				'error'             => __('Error', 'intersoccer-product-variations'),
 				'creating'          => __('Creating program…', 'intersoccer-product-variations'),
 				'refreshing'        => __('Refreshing…', 'intersoccer-product-variations'),
+				'syncing_wpml'      => __('Syncing WPML languages…', 'intersoccer-product-variations'),
 				'select_type'       => __('Please select a program type.', 'intersoccer-product-variations'),
 				'enter_name'        => __('Please enter a program name.', 'intersoccer-product-variations'),
 				'select_target_year'=> __('Select or enter a target program year before applying Duplicate to year.', 'intersoccer-product-variations'),
@@ -448,6 +451,46 @@ class InterSoccer_Program_Manager {
 							}
 						}
 					}
+				} elseif ($action === 'sync_wpml_languages') {
+					@set_time_limit(0);
+					$created  = 0;
+					$synced   = 0;
+					$failed   = 0;
+					$messages = [];
+					foreach ($product_ids as $pid) {
+						if (!function_exists('intersoccer_pm_sync_product_translations')) {
+							$failed++;
+							continue;
+						}
+						$result = intersoccer_pm_sync_product_translations($pid);
+						$processed++;
+						$created += count($result['parents_created'] ?? []);
+						$synced  += count($result['parents_synced'] ?? []);
+						if (empty($result['ok']) && !empty($result['errors'])) {
+							$failed++;
+						}
+						if (!empty($result['message'])) {
+							$messages[] = sprintf('#%d: %s', (int) ($result['source_product_id'] ?? $pid), $result['message']);
+						}
+					}
+					$summary = sprintf(
+						/* translators: 1: products processed, 2: languages created, 3: languages refreshed, 4: failures */
+						__('%1$d products processed — WPML: %2$d language(s) created, %3$d refreshed, %4$d with errors.', 'intersoccer-product-variations'),
+						$processed,
+						$created,
+						$synced,
+						$failed
+					);
+					$class = $failed > 0 ? 'notice-warning' : 'notice-success';
+					echo '<div class="notice ' . esc_attr($class) . ' is-dismissible"><p>' . esc_html($summary) . '</p>';
+					if ($messages !== []) {
+						echo '<ul style="margin-left:1.5em;list-style:disc;">';
+						foreach (array_slice($messages, 0, 20) as $msg) {
+							echo '<li>' . esc_html($msg) . '</li>';
+						}
+						echo '</ul>';
+					}
+					echo '</div>';
 				}
 			} else {
 				echo '<div class="notice notice-error is-dismissible"><p>' . esc_html__('Bulk action could not be verified (security check failed). Please reload the Program Manager page and try again.', 'intersoccer-product-variations') . '</p></div>';
@@ -644,6 +687,16 @@ class InterSoccer_Program_Manager {
 				&nbsp;|&nbsp;
 				<a href="<?php echo esc_url($duplicate_url); ?>"><?php esc_html_e('Duplicate Program', 'intersoccer-product-variations'); ?></a>
 			</p>
+			<?php if (function_exists('intersoccer_pm_wpml_available') && intersoccer_pm_wpml_available()) : ?>
+			<p class="intersoccer-pm-wpml-sync-row" style="margin:8px 0 16px;">
+				<button type="button" class="button button-secondary" id="intersoccer-pm-sync-wpml-btn" data-product-id="<?php echo esc_attr((string) $product_id); ?>">
+					<?php esc_html_e('Sync all languages (WPML)', 'intersoccer-product-variations'); ?>
+				</button>
+				<span id="intersoccer-pm-sync-wpml-status" style="margin-left:8px;"></span>
+				<br />
+				<span class="description"><?php esc_html_e('Creates or refreshes FR/DE translations from the default language (EN), copying shared attribute slugs, camp schedule, prices, and course meta. Edit the catalogue in English first.', 'intersoccer-product-variations'); ?></span>
+			</p>
+			<?php endif; ?>
 			<p class="intersoccer-pm-detail-status-row" style="margin:12px 0 20px;">
 				<label for="intersoccer-pm-detail-status" style="font-weight:600;margin-right:8px;">
 					<?php esc_html_e('Status', 'intersoccer-product-variations'); ?>
@@ -2036,6 +2089,41 @@ class InterSoccer_Program_Manager {
 		]);
 	}
 
+	/**
+	 * AJAX: create/link FR/DE translations via WPML/WCML and fan out EN catalogue data.
+	 */
+	public static function ajax_sync_wpml_languages() {
+		check_ajax_referer(self::NONCE_ACTION, 'nonce');
+
+		if (!current_user_can(self::CAPABILITY)) {
+			wp_send_json_error(['message' => __('Permission denied.', 'intersoccer-product-variations')]);
+		}
+
+		if (!function_exists('intersoccer_pm_sync_product_translations')) {
+			wp_send_json_error(['message' => __('WPML sync is not available.', 'intersoccer-product-variations')]);
+		}
+
+		$product_id = isset($_POST['product_id']) ? absint($_POST['product_id']) : 0;
+		$result     = intersoccer_pm_sync_product_translations($product_id);
+
+		if (empty($result['ok']) && in_array('invalid_product', $result['errors'] ?? [], true)) {
+			wp_send_json_error(['message' => $result['message'] ?: __('Invalid product.', 'intersoccer-product-variations'), 'result' => $result]);
+		}
+		if (empty($result['ok']) && in_array('wpml_unavailable', $result['errors'] ?? [], true)) {
+			wp_send_json_error(['message' => $result['message'] ?: __('WPML is not available.', 'intersoccer-product-variations'), 'result' => $result]);
+		}
+		if (empty($result['ok']) && in_array('not_variable', $result['errors'] ?? [], true)) {
+			wp_send_json_error(['message' => $result['message'] ?: __('Invalid product.', 'intersoccer-product-variations'), 'result' => $result]);
+		}
+
+		$source_id = (int) ($result['source_product_id'] ?? $product_id);
+		wp_send_json_success([
+			'result'       => $result,
+			'completeness' => self::get_product_completeness($source_id),
+			'message'      => $result['message'] ?? __('WPML sync complete.', 'intersoccer-product-variations'),
+		]);
+	}
+
 	public static function ajax_quick_edit() {
 		check_ajax_referer(self::NONCE_ACTION, 'nonce');
 
@@ -3050,11 +3138,15 @@ class InterSoccer_Program_List_Table extends WP_List_Table {
 	}
 
 	public function get_bulk_actions() {
-		return [
+		$actions = [
 			'refresh_attrs'       => __('Refresh Variation Attributes', 'intersoccer-product-variations'),
 			'scaffold_variations' => __('Auto-scaffold Missing Variations', 'intersoccer-product-variations'),
 			'duplicate_to_year'   => __('Duplicate to year…', 'intersoccer-product-variations'),
 		];
+		if (function_exists('intersoccer_pm_wpml_available') && intersoccer_pm_wpml_available()) {
+			$actions['sync_wpml_languages'] = __('Sync all languages (WPML)', 'intersoccer-product-variations');
+		}
+		return $actions;
 	}
 
 	public function prepare_items() {

--- a/intersoccer-product-variations.php
+++ b/intersoccer-product-variations.php
@@ -326,6 +326,7 @@ $includes = [
     'includes/woocommerce/order-meta-contract.php',
     'includes/woocommerce/attribute-enforcement.php',
     'includes/woocommerce/admin-ui.php',
+    'includes/woocommerce/pm-wpml-sync.php',
     'includes/woocommerce/program-manager.php',
     'includes/woocommerce/product-types.php',
     'includes/woocommerce/product-course.php',

--- a/js/program-manager.js
+++ b/js/program-manager.js
@@ -1134,6 +1134,40 @@
 	});
 
 	// =========================================================================
+	// Detail view: Sync all languages (WPML)
+	// =========================================================================
+
+	$(document).on('click', '#intersoccer-pm-sync-wpml-btn', function() {
+		var $btn = $(this);
+		var productId = $btn.data('product-id');
+		var $status = $('#intersoccer-pm-sync-wpml-status');
+		var confirmMsg = (PM.i18n && PM.i18n.confirm_sync_wpml)
+			? PM.i18n.confirm_sync_wpml
+			: 'Sync all languages (WPML)?';
+		if (!window.confirm(confirmMsg)) {
+			return;
+		}
+		$status.text((PM.i18n && PM.i18n.syncing_wpml) || 'Syncing…').css('color', '#666');
+		$btn.prop('disabled', true);
+		$.post(PM.ajax_url, {
+			action: 'intersoccer_pm_sync_wpml_languages',
+			nonce: PM.nonce,
+			product_id: productId
+		}).done(function(response) {
+			$btn.prop('disabled', false);
+			if (!response.success) {
+				$status.text(response.data && response.data.message ? response.data.message : PM.i18n.error).css('color', 'red');
+				return;
+			}
+			$status.text(response.data.message || 'Synced').css('color', 'green');
+			setTimeout(function() { window.location.reload(); }, 1200);
+		}).fail(function() {
+			$btn.prop('disabled', false);
+			$status.text(PM.i18n.error).css('color', 'red');
+		});
+	});
+
+	// =========================================================================
 	// Detail view: product status (draft / publish / private)
 	// =========================================================================
 

--- a/tests/PmWpmlSyncTest.php
+++ b/tests/PmWpmlSyncTest.php
@@ -1,0 +1,368 @@
+<?php
+/**
+ * Program Manager Sync all languages (WPML) orchestration tests.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class PmWpmlSyncTest extends TestCase {
+	private int $en_parent = 8001;
+	private int $fr_parent = 8002;
+	private int $de_parent = 8003;
+	private int $en_var = 8101;
+	private int $fr_var = 8102;
+	private int $de_var = 8103;
+
+	/** @var array<int,object> */
+	private static array $products = [];
+
+	/** @var array<int,array<string,int>> */
+	private static array $product_lang_map = [];
+
+	/** @var array<int,array<string,int>> */
+	private static array $variation_lang_map = [];
+
+	/** @var array<string,int> */
+	private static array $make_duplicate_calls = [];
+
+	/** @var int */
+	private static int $wcml_sync_calls = 0;
+
+	protected function setUp(): void {
+		parent::setUp();
+		if (class_exists('MockMetaData')) {
+			MockMetaData::reset();
+		}
+		if (class_exists('MockFilters')) {
+			MockFilters::reset();
+		}
+
+		self::$products = [];
+		self::$product_lang_map = [];
+		self::$variation_lang_map = [];
+		self::$make_duplicate_calls = [];
+		self::$wcml_sync_calls = 0;
+
+		if (!defined('ICL_SITEPRESS_VERSION')) {
+			define('ICL_SITEPRESS_VERSION', '4.6-test');
+		}
+
+		require_once dirname(__DIR__) . '/includes/language-helpers.php';
+		require_once dirname(__DIR__) . '/includes/woocommerce/camp-schedule.php';
+		require_once dirname(__DIR__) . '/includes/woocommerce/pm-wpml-sync.php';
+
+		$this->installWcMocks();
+		$this->installWpmlFilters();
+	}
+
+	private function installWcMocks(): void {
+		$en_parent = $this->en_parent;
+		$en_var = $this->en_var;
+
+		if (!class_exists('WC_Product_Variation', false)) {
+			eval('class WC_Product_Variation {}');
+		}
+		if (!class_exists('PmWpmlMockVariableProduct', false)) {
+			eval(<<<'PHP'
+class PmWpmlMockVariableProduct {
+	public $id;
+	public $children;
+	public $type = 'variable';
+	public function __construct($id, $children = []) {
+		$this->id = (int) $id;
+		$this->children = array_map('intval', $children);
+	}
+	public function get_id() { return $this->id; }
+	public function is_type($type) { return $type === $this->type; }
+	public function get_children() { return $this->children; }
+}
+class PmWpmlMockVariationProduct extends WC_Product_Variation {
+	public $id;
+	public $attrs = [];
+	public $regular_price = '';
+	public $price = '';
+	public function __construct($id) { $this->id = (int) $id; }
+	public function get_id() { return $this->id; }
+	public function get_attributes() { return $this->attrs; }
+	public function get_regular_price() { return $this->regular_price; }
+	public function get_price() { return $this->price; }
+	public function set_attributes($attrs) { $this->attrs = $attrs; }
+	public function set_regular_price($p) { $this->regular_price = $p; }
+	public function set_price($p) { $this->price = $p; }
+	public function save() { return $this->id; }
+	public function get_parent_id() { return 0; }
+}
+PHP
+			);
+		}
+
+		self::$products[$en_parent] = new PmWpmlMockVariableProduct($en_parent, [$en_var]);
+		self::$products[$en_var] = new PmWpmlMockVariationProduct($en_var);
+		self::$products[$en_var]->attrs = [
+			'pa_intersoccer-venues' => 'geneve-stade',
+			'pa_age-group' => '5-13y-full-day',
+			'pa_camp-terms' => 'week-1',
+		];
+		self::$products[$en_var]->regular_price = '250';
+		self::$products[$en_var]->price = '250';
+
+		MockFilters::$filters['intersoccer_pm_wpml_get_product'] = static function ($pre, $id) {
+			return PmWpmlSyncTest::getProduct((int) $id);
+		};
+
+		if (!function_exists('wc_delete_product_transients')) {
+			function wc_delete_product_transients($id) {
+				return true;
+			}
+		}
+		if (!function_exists('wp_set_object_terms')) {
+			function wp_set_object_terms($object_id, $terms, $taxonomy, $append = false) {
+				return true;
+			}
+		}
+		if (!function_exists('get_post')) {
+			function get_post($id) {
+				return (object) ['ID' => (int) $id, 'post_type' => 'product'];
+			}
+		}
+	}
+
+	public static function getProduct(int $id) {
+		return self::$products[$id] ?? false;
+	}
+
+	private function installWpmlFilters(): void {
+		$en_parent = $this->en_parent;
+		$fr_parent = $this->fr_parent;
+		$de_parent = $this->de_parent;
+		$en_var = $this->en_var;
+		$fr_var = $this->fr_var;
+		$de_var = $this->de_var;
+
+		// Start with no FR/DE parents — create path.
+		self::$product_lang_map = [
+			$en_parent => ['en' => $en_parent],
+		];
+		self::$variation_lang_map = [
+			$en_var => ['en' => $en_var],
+		];
+
+		MockFilters::$filters['wpml_active_languages'] = static function () {
+			return [
+				'en' => ['code' => 'en'],
+				'fr' => ['code' => 'fr'],
+				'de' => ['code' => 'de'],
+			];
+		};
+		MockFilters::$filters['wpml_default_language'] = static function () {
+			return 'en';
+		};
+		MockFilters::$filters['wpml_current_language'] = static function () {
+			return 'en';
+		};
+		MockFilters::$filters['wpml_element_language_code'] = static function ($value, $args = null) use ($en_parent, $en_var) {
+			$id = is_array($args) ? (int) ($args['element_id'] ?? 0) : 0;
+			if ($id === $en_parent || $id === $en_var) {
+				return 'en';
+			}
+			return $value;
+		};
+		MockFilters::$filters['wpml_object_id'] = static function ($id, $type = null, $return_original = null, $lang = null) {
+			$id = (int) $id;
+			$lang = $lang ?: 'en';
+			$map = ($type === 'product_variation')
+				? PmWpmlSyncTest::$variation_lang_map
+				: PmWpmlSyncTest::$product_lang_map;
+			if (!isset($map[$id])) {
+				// Look up by any known id in values.
+				foreach ($map as $row) {
+					if (in_array($id, $row, true)) {
+						return $row[$lang] ?? ($return_original ? ($row['en'] ?? $id) : 0);
+					}
+				}
+				return $return_original ? $id : 0;
+			}
+			if (!isset($map[$id][$lang])) {
+				return $return_original ? ($map[$id]['en'] ?? $id) : 0;
+			}
+			return $map[$id][$lang];
+		};
+
+		MockFilters::$filters['intersoccer_pm_wpml_make_duplicate'] = static function ($pre, $master_id, $lang) use ($en_parent, $fr_parent, $de_parent, $en_var, $fr_var, $de_var) {
+			$master_id = (int) $master_id;
+			$lang = (string) $lang;
+			PmWpmlSyncTest::$make_duplicate_calls[$lang] = $master_id;
+			$new_id = $lang === 'fr' ? $fr_parent : ($lang === 'de' ? $de_parent : 0);
+			if ($new_id <= 0) {
+				return false;
+			}
+			PmWpmlSyncTest::$product_lang_map[$en_parent][$lang] = $new_id;
+			PmWpmlSyncTest::$product_lang_map[$new_id] = PmWpmlSyncTest::$product_lang_map[$en_parent];
+			PmWpmlSyncTest::$products[$new_id] = new PmWpmlMockVariableProduct($new_id, []);
+			return $new_id;
+		};
+
+		MockFilters::$filters['intersoccer_pm_wcml_synchronize_product'] = static function ($handled, $product_post, $tr_ids, $lang_map) use ($en_var, $fr_var, $de_var, $en_parent) {
+			PmWpmlSyncTest::$wcml_sync_calls++;
+			// Link variation siblings after parent create/sync.
+			PmWpmlSyncTest::$variation_lang_map[$en_var] = [
+				'en' => $en_var,
+				'fr' => $fr_var,
+				'de' => $de_var,
+			];
+			PmWpmlSyncTest::$variation_lang_map[$fr_var] = PmWpmlSyncTest::$variation_lang_map[$en_var];
+			PmWpmlSyncTest::$variation_lang_map[$de_var] = PmWpmlSyncTest::$variation_lang_map[$en_var];
+			PmWpmlSyncTest::$products[$fr_var] = new PmWpmlMockVariationProduct($fr_var);
+			PmWpmlSyncTest::$products[$de_var] = new PmWpmlMockVariationProduct($de_var);
+			foreach ($tr_ids as $tr_id) {
+				if (isset(PmWpmlSyncTest::$products[(int) $tr_id])) {
+					PmWpmlSyncTest::$products[(int) $tr_id]->children = [$fr_var, $de_var];
+				}
+			}
+			return true;
+		};
+	}
+
+	public function test_no_active_languages_returns_error(): void {
+		MockFilters::$filters['wpml_active_languages'] = static function () {
+			return null;
+		};
+		$result = intersoccer_pm_sync_product_translations($this->en_parent);
+		$this->assertFalse($result['ok']);
+		$this->assertContains('no_languages', $result['errors']);
+	}
+
+	public function test_not_variable_returns_error(): void {
+		self::$products[$this->en_parent]->type = 'simple';
+		$result = intersoccer_pm_sync_product_translations($this->en_parent);
+		$this->assertFalse($result['ok']);
+		$this->assertContains('not_variable', $result['errors']);
+	}
+
+	public function test_create_path_duplicates_missing_languages_and_fans_out(): void {
+		update_post_meta($this->en_var, '_camp_start_date', '2026-07-06');
+		update_post_meta($this->en_var, '_camp_end_date', '2026-07-10');
+		update_post_meta($this->en_var, '_camp_week_index', 1);
+		update_post_meta($this->en_var, 'attribute_pa_intersoccer-venues', 'geneve-stade');
+
+		$result = intersoccer_pm_sync_product_translations($this->en_parent);
+
+		$this->assertTrue($result['ok'], $result['message'] ?? '');
+		$this->assertArrayHasKey('fr', $result['parents_created']);
+		$this->assertArrayHasKey('de', $result['parents_created']);
+		$this->assertSame($this->fr_parent, $result['parents_created']['fr']);
+		$this->assertSame($this->de_parent, $result['parents_created']['de']);
+		$this->assertSame([], $result['parents_synced']);
+		$this->assertArrayHasKey('fr', self::$make_duplicate_calls);
+		$this->assertArrayHasKey('de', self::$make_duplicate_calls);
+		$this->assertSame(1, self::$wcml_sync_calls);
+		$this->assertGreaterThan(0, $result['meta_synced']);
+
+		$this->assertSame('2026-07-06', get_post_meta($this->fr_var, '_camp_start_date', true));
+		$this->assertSame('2026-07-10', get_post_meta($this->de_var, '_camp_end_date', true));
+		$this->assertSame('geneve-stade', get_post_meta($this->fr_var, 'attribute_pa_intersoccer-venues', true));
+		$this->assertSame('geneve-stade', get_post_meta($this->de_var, 'attribute_pa_intersoccer-venues', true));
+	}
+
+	public function test_sync_path_refreshes_existing_translations_without_duplicate(): void {
+		// Pre-link parents.
+		self::$product_lang_map = [
+			$this->en_parent => [
+				'en' => $this->en_parent,
+				'fr' => $this->fr_parent,
+				'de' => $this->de_parent,
+			],
+			$this->fr_parent => [
+				'en' => $this->en_parent,
+				'fr' => $this->fr_parent,
+				'de' => $this->de_parent,
+			],
+			$this->de_parent => [
+				'en' => $this->en_parent,
+				'fr' => $this->fr_parent,
+				'de' => $this->de_parent,
+			],
+		];
+		self::$products[$this->fr_parent] = new PmWpmlMockVariableProduct($this->fr_parent, [$this->fr_var]);
+		self::$products[$this->de_parent] = new PmWpmlMockVariableProduct($this->de_parent, [$this->de_var]);
+		self::$variation_lang_map = [
+			$this->en_var => ['en' => $this->en_var, 'fr' => $this->fr_var, 'de' => $this->de_var],
+			$this->fr_var => ['en' => $this->en_var, 'fr' => $this->fr_var, 'de' => $this->de_var],
+			$this->de_var => ['en' => $this->en_var, 'fr' => $this->fr_var, 'de' => $this->de_var],
+		];
+		self::$products[$this->fr_var] = new PmWpmlMockVariationProduct($this->fr_var);
+		self::$products[$this->de_var] = new PmWpmlMockVariationProduct($this->de_var);
+
+		update_post_meta($this->en_var, '_camp_start_date', '2026-08-03');
+		update_post_meta($this->en_var, '_camp_end_date', '2026-08-07');
+		update_post_meta($this->en_var, '_camp_week_index', 2);
+
+		$result = intersoccer_pm_sync_product_translations($this->en_parent);
+
+		$this->assertTrue($result['ok'], $result['message'] ?? '');
+		$this->assertSame([], $result['parents_created']);
+		$this->assertArrayHasKey('fr', $result['parents_synced']);
+		$this->assertArrayHasKey('de', $result['parents_synced']);
+		$this->assertSame([], self::$make_duplicate_calls);
+		$this->assertSame(1, self::$wcml_sync_calls);
+		$this->assertSame('2026-08-03', get_post_meta($this->fr_var, '_camp_start_date', true));
+		$this->assertSame('2026-08-07', get_post_meta($this->de_var, '_camp_end_date', true));
+	}
+
+	public function test_resolves_to_default_language_source(): void {
+		self::$product_lang_map = [
+			$this->en_parent => [
+				'en' => $this->en_parent,
+				'fr' => $this->fr_parent,
+			],
+			$this->fr_parent => [
+				'en' => $this->en_parent,
+				'fr' => $this->fr_parent,
+			],
+		];
+		self::$products[$this->fr_parent] = new PmWpmlMockVariableProduct($this->fr_parent, []);
+
+		$resolved = intersoccer_pm_wpml_resolve_source_product($this->fr_parent);
+		$this->assertSame($this->en_parent, $resolved['id']);
+		$this->assertSame('en', $resolved['default_lang']);
+	}
+
+	public function test_idempotent_second_run_still_ok(): void {
+		self::$product_lang_map = [
+			$this->en_parent => [
+				'en' => $this->en_parent,
+				'fr' => $this->fr_parent,
+				'de' => $this->de_parent,
+			],
+			$this->fr_parent => [
+				'en' => $this->en_parent,
+				'fr' => $this->fr_parent,
+				'de' => $this->de_parent,
+			],
+			$this->de_parent => [
+				'en' => $this->en_parent,
+				'fr' => $this->fr_parent,
+				'de' => $this->de_parent,
+			],
+		];
+		self::$products[$this->fr_parent] = new PmWpmlMockVariableProduct($this->fr_parent, [$this->fr_var]);
+		self::$products[$this->de_parent] = new PmWpmlMockVariableProduct($this->de_parent, [$this->de_var]);
+		self::$variation_lang_map = [
+			$this->en_var => ['en' => $this->en_var, 'fr' => $this->fr_var, 'de' => $this->de_var],
+			$this->fr_var => ['en' => $this->en_var, 'fr' => $this->fr_var, 'de' => $this->de_var],
+			$this->de_var => ['en' => $this->en_var, 'fr' => $this->fr_var, 'de' => $this->de_var],
+		];
+		self::$products[$this->fr_var] = new PmWpmlMockVariationProduct($this->fr_var);
+		self::$products[$this->de_var] = new PmWpmlMockVariationProduct($this->de_var);
+
+		$first = intersoccer_pm_sync_product_translations($this->en_parent);
+		self::$make_duplicate_calls = [];
+		self::$wcml_sync_calls = 0;
+		$second = intersoccer_pm_sync_product_translations($this->en_parent);
+
+		$this->assertTrue($first['ok']);
+		$this->assertTrue($second['ok']);
+		$this->assertSame([], $second['parents_created']);
+		$this->assertSame([], self::$make_duplicate_calls);
+	}
+}


### PR DESCRIPTION
Restores EN→FR/DE create/refresh with parent attrs, variation fan-out, and status inheritance for the year-roll catalogue workflow.