### PR TITLE
Raise half-day max-age grace to 96 months so children up to 13 can book.

### DIFF
--- a/includes/woocommerce/age-group-verification.php
+++ b/includes/woocommerce/age-group-verification.php
@@ -571,7 +571,7 @@ function intersoccer_get_age_restriction_settings_defaults() {
         'grace_enabled' => true,
         'below_min_months' => 2,
         'above_max_months' => 1,
-        'half_day_above_max_months' => 24,
+        'half_day_above_max_months' => 96,
         'strict_missing_reference_date' => false,
     ];
 }
@@ -592,7 +592,7 @@ function intersoccer_sanitize_age_restriction_settings($input) {
         'grace_enabled' => !empty($input['grace_enabled']),
         'below_min_months' => max(0, min(12, (int) ($input['below_min_months'] ?? $defaults['below_min_months']))),
         'above_max_months' => max(0, min(12, (int) ($input['above_max_months'] ?? $defaults['above_max_months']))),
-        'half_day_above_max_months' => max(0, min(36, (int) ($input['half_day_above_max_months'] ?? $defaults['half_day_above_max_months']))),
+        'half_day_above_max_months' => max(0, min(120, (int) ($input['half_day_above_max_months'] ?? $defaults['half_day_above_max_months']))),
         'strict_missing_reference_date' => !empty($input['strict_missing_reference_date']),
     ];
 }
@@ -608,6 +608,11 @@ function intersoccer_get_age_restriction_settings() {
         intersoccer_get_age_restriction_settings_defaults(),
         is_array($stored) ? $stored : []
     );
+
+    // Legacy default was 24 (max age 5 → ~7y). Remap so saved sites get age-13 half-day grace.
+    if ((int) ($merged['half_day_above_max_months'] ?? 0) === 24) {
+        $merged['half_day_above_max_months'] = 96;
+    }
 
     /**
      * @param array $merged Settings array.
@@ -827,7 +832,7 @@ function intersoccer_validate_line_player_age($user_id, $player_index, $product_
         && intersoccer_is_half_day_age_group($label, $slug)
         && ($bounds['max'] ?? null) !== null
     ) {
-        $settings['above_max_months'] = (int) ($settings['half_day_above_max_months'] ?? 24);
+        $settings['above_max_months'] = (int) ($settings['half_day_above_max_months'] ?? 96);
     }
     $age_result = intersoccer_player_age_within_bounds($dob_ymd, $ref, $bounds, $settings);
     if ($age_result['age_years'] === null) {

--- a/includes/woocommerce/age-restriction-settings.php
+++ b/includes/woocommerce/age-restriction-settings.php
@@ -117,8 +117,8 @@ function intersoccer_age_restriction_settings_page() {
                         <label for="half_day_above_max_months"><?php esc_html_e('Half-day months above maximum', 'intersoccer-product-variations'); ?></label>
                     </th>
                     <td>
-                        <input type="number" name="half_day_above_max_months" id="half_day_above_max_months" value="<?php echo esc_attr((int) ($settings['half_day_above_max_months'] ?? 24)); ?>" min="0" max="36" step="1" class="small-text">
-                        <p class="description"><?php esc_html_e('Additional months above the listed maximum age for half-day camp variations only. Requires age grace to be enabled. Example: max age 5 with 24 months allows a child up to 7 years on the program start date.', 'intersoccer-product-variations'); ?></p>
+                        <input type="number" name="half_day_above_max_months" id="half_day_above_max_months" value="<?php echo esc_attr((int) ($settings['half_day_above_max_months'] ?? 96)); ?>" min="0" max="120" step="1" class="small-text">
+                        <p class="description"><?php esc_html_e('Additional months above the listed maximum age for half-day camp variations only. Requires age grace to be enabled. Example: max age 5 with 96 months allows a child up to 13 years on the program start date.', 'intersoccer-product-variations'); ?></p>
                     </td>
                 </tr>
                 <tr>
@@ -158,7 +158,7 @@ function intersoccer_register_age_restriction_settings_strings() {
         'Months below minimum',
         'Months above maximum',
         'Half-day months above maximum',
-        'Additional months above the listed maximum age for half-day camp variations only. Requires age grace to be enabled. Example: max age 5 with 24 months allows a child up to 7 years on the program start date.',
+        'Additional months above the listed maximum age for half-day camp variations only. Requires age grace to be enabled. Example: max age 5 with 96 months allows a child up to 13 years on the program start date.',
         'Strict missing start date',
         'Block checkout when the program start date cannot be determined',
         'By default, bookings proceed when start date metadata is missing. Enable this to reject those bookings.',

--- a/intersoccer-product-variations.php
+++ b/intersoccer-product-variations.php
@@ -117,7 +117,7 @@ add_action('init', function () {
             'Months below minimum',
             'Months above maximum',
             'Half-day months above maximum',
-            'Additional months above the listed maximum age for half-day camp variations only. Requires age grace to be enabled. Example: max age 5 with 24 months allows a child up to 7 years on the program start date.',
+            'Additional months above the listed maximum age for half-day camp variations only. Requires age grace to be enabled. Example: max age 5 with 96 months allows a child up to 13 years on the program start date.',
             'Strict missing start date',
             '%d%% Camp Combo Discount (Child %d)',
             '%d%% Course Multi-Child Discount (Child %d)',

--- a/tests/AgeGroupVerificationTest.php
+++ b/tests/AgeGroupVerificationTest.php
@@ -66,7 +66,7 @@ class AgeGroupVerificationTest extends TestCase {
         parent::tearDown();
     }
 
-    private function graceSettings($below = 2, $above = 1, $enabled = true, $halfDayAbove = 24) {
+    private function graceSettings($below = 2, $above = 1, $enabled = true, $halfDayAbove = 96) {
         return [
             'grace_enabled' => $enabled,
             'below_min_months' => $below,
@@ -306,7 +306,40 @@ class AgeGroupVerificationTest extends TestCase {
         $this->assertTrue($settings['grace_enabled']);
         $this->assertSame(2, $settings['below_min_months']);
         $this->assertSame(1, $settings['above_max_months']);
-        $this->assertSame(24, $settings['half_day_above_max_months']);
+        $this->assertSame(96, $settings['half_day_above_max_months']);
+    }
+
+    public function test_sanitize_half_day_above_max_allows_96_and_caps_at_120() {
+        $ok = intersoccer_sanitize_age_restriction_settings([
+            'grace_enabled' => 1,
+            'below_min_months' => 2,
+            'above_max_months' => 1,
+            'half_day_above_max_months' => 96,
+        ]);
+        $this->assertSame(96, $ok['half_day_above_max_months']);
+
+        $capped = intersoccer_sanitize_age_restriction_settings([
+            'grace_enabled' => 1,
+            'below_min_months' => 2,
+            'above_max_months' => 1,
+            'half_day_above_max_months' => 200,
+        ]);
+        $this->assertSame(120, $capped['half_day_above_max_months']);
+    }
+
+    public function test_get_age_restriction_settings_remaps_legacy_24_to_96() {
+        global $intersoccer_test_options;
+        $intersoccer_test_options = [
+            'intersoccer_age_restriction_settings' => [
+                'grace_enabled' => true,
+                'below_min_months' => 2,
+                'above_max_months' => 1,
+                'half_day_above_max_months' => 24,
+                'strict_missing_reference_date' => false,
+            ],
+        ];
+        $settings = intersoccer_get_age_restriction_settings();
+        $this->assertSame(96, $settings['half_day_above_max_months']);
     }
 
     public function test_parse_age_group_bounds_half_day_label() {
@@ -317,12 +350,14 @@ class AgeGroupVerificationTest extends TestCase {
     }
 
     public function test_half_day_uses_extended_above_max_months() {
-        $settings = $this->graceSettings(2, 1, true, 24);
+        $settings = $this->graceSettings(2, 1, true, 96);
         $bounds = ['min' => 3, 'max' => 5];
-        $pass = intersoccer_player_age_within_bounds('2018-04-01', '2025-03-01', $bounds, array_merge($settings, ['above_max_months' => 24]));
+        // Age 13.0 on start: 5y max + 96 months grace.
+        $pass = intersoccer_player_age_within_bounds('2012-03-01', '2025-03-01', $bounds, array_merge($settings, ['above_max_months' => 96]));
         $this->assertTrue($pass['matches']);
 
-        $fail = intersoccer_player_age_within_bounds('2017-01-01', '2025-03-01', $bounds, array_merge($settings, ['above_max_months' => 24]));
+        // One month older than 13.0 → outside grace.
+        $fail = intersoccer_player_age_within_bounds('2012-02-01', '2025-03-01', $bounds, array_merge($settings, ['above_max_months' => 96]));
         $this->assertFalse($fail['matches']);
     }
 }


### PR DESCRIPTION
Remap the legacy stored default of 24 and lift the admin sanitize cap to 120.